### PR TITLE
feat(clonable): add 7 missing event types and nsec destination login

### DIFF
--- a/components/Clonable.tsx
+++ b/components/Clonable.tsx
@@ -23,9 +23,16 @@ import {
   publishClonedFollows,
   publishClonedMutes,
   publishClonedRelayList,
+  publishClonedPinnedNotes,
+  publishClonedBookmarks,
+  publishClonedCommunities,
+  publishClonedSearchRelays,
+  publishClonedInterests,
+  publishClonedEmojiLists,
+  publishClonedDmRelays,
   CloneableData,
 } from "@/lib/clonableService";
-import { hexToNpub } from "@/lib/nostr";
+import { hexToNpub, DEFAULT_RELAYS } from "@/lib/nostr";
 import { Profile } from "@/types";
 
 type Step = "mode" | "input" | "preview" | "publishing" | "done";
@@ -36,7 +43,42 @@ interface PublishStatus {
   follows: "pending" | "publishing" | "success" | "error" | "skipped";
   mutes: "pending" | "publishing" | "success" | "error" | "skipped";
   relays: "pending" | "publishing" | "success" | "error" | "skipped";
+  pinnedNotes: "pending" | "publishing" | "success" | "error" | "skipped";
+  bookmarks: "pending" | "publishing" | "success" | "error" | "skipped";
+  communities: "pending" | "publishing" | "success" | "error" | "skipped";
+  searchRelays: "pending" | "publishing" | "success" | "error" | "skipped";
+  interests: "pending" | "publishing" | "success" | "error" | "skipped";
+  emojiLists: "pending" | "publishing" | "success" | "error" | "skipped";
+  dmRelays: "pending" | "publishing" | "success" | "error" | "skipped";
 }
+
+const INITIAL_SELECTED = {
+  profile: true,
+  follows: true,
+  mutes: true,
+  relays: true,
+  pinnedNotes: true,
+  bookmarks: true,
+  communities: true,
+  searchRelays: true,
+  interests: true,
+  emojiLists: true,
+  dmRelays: true,
+};
+
+const INITIAL_PUBLISH_STATUS: PublishStatus = {
+  profile: "pending",
+  follows: "pending",
+  mutes: "pending",
+  relays: "pending",
+  pinnedNotes: "pending",
+  bookmarks: "pending",
+  communities: "pending",
+  searchRelays: "pending",
+  interests: "pending",
+  emojiLists: "pending",
+  dmRelays: "pending",
+};
 
 export default function Clonable() {
   const { session } = useAuth();
@@ -49,28 +91,25 @@ export default function Clonable() {
   const [fetching, setFetching] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [cloneData, setCloneData] = useState<CloneableData | null>(null);
-  const [selected, setSelected] = useState({
-    profile: true,
-    follows: true,
-    mutes: true,
-    relays: true,
-  });
-  const [publishStatus, setPublishStatus] = useState<PublishStatus>({
-    profile: "pending",
-    follows: "pending",
-    mutes: "pending",
-    relays: "pending",
-  });
-  const [publishErrors, setPublishErrors] = useState<Record<string, string>>(
-    {},
-  );
+  const [selected, setSelected] = useState(INITIAL_SELECTED);
+  const [publishStatus, setPublishStatus] = useState<PublishStatus>(INITIAL_PUBLISH_STATUS);
+  const [publishErrors, setPublishErrors] = useState<Record<string, string>>({});
   const nsecSignerRef = useRef<NsecSigner | null>(null);
 
+  // Destination nsec state (used when no session is active)
+  const [destKeyInput, setDestKeyInput] = useState("");
+  const [destInputError, setDestInputError] = useState<string | null>(null);
+  const [destPubkey, setDestPubkey] = useState<string | null>(null);
+  const destSignerRef = useRef<NsecSigner | null>(null);
+
   const reset = () => {
-    // Destroy nsec signer if it exists
     if (nsecSignerRef.current) {
       nsecSignerRef.current.destroy();
       nsecSignerRef.current = null;
+    }
+    if (destSignerRef.current) {
+      destSignerRef.current.destroy();
+      destSignerRef.current = null;
     }
     setStep("mode");
     setMode(null);
@@ -81,14 +120,30 @@ export default function Clonable() {
     setFetching(false);
     setFetchError(null);
     setCloneData(null);
-    setSelected({ profile: true, follows: true, mutes: true, relays: true });
-    setPublishStatus({
-      profile: "pending",
-      follows: "pending",
-      mutes: "pending",
-      relays: "pending",
-    });
+    setSelected(INITIAL_SELECTED);
+    setPublishStatus(INITIAL_PUBLISH_STATUS);
     setPublishErrors({});
+    setDestKeyInput("");
+    setDestInputError(null);
+    setDestPubkey(null);
+  };
+
+  const handleDestNsec = async () => {
+    const trimmed = destKeyInput.trim();
+    setDestInputError(null);
+    if (!trimmed.startsWith("nsec1")) {
+      setDestInputError("Please enter a valid nsec (starts with nsec1)");
+      return;
+    }
+    try {
+      const signer = NsecSigner.fromNsec(trimmed);
+      const pubkey = await signer.getPublicKey();
+      destSignerRef.current = signer;
+      setDestPubkey(pubkey);
+      setDestKeyInput("");
+    } catch {
+      setDestInputError("Invalid nsec. Please check and try again.");
+    }
   };
 
   const handleModeSelect = (selectedMode: Mode) => {
@@ -154,9 +209,14 @@ export default function Clonable() {
         nsecSignerRef.current = signer;
       }
 
-      // Check that source is different from logged-in account
+      // Check that source is different from logged-in or destination account
       if (session && pubkey === session.pubkey) {
         setFetchError("The source account is the same as your logged-in account. Please enter a different key.");
+        setFetching(false);
+        return;
+      }
+      if (!session && destPubkey && pubkey === destPubkey) {
+        setFetchError("The source account is the same as the destination account. Please enter a different key.");
         setFetching(false);
         return;
       }
@@ -184,17 +244,19 @@ export default function Clonable() {
   };
 
   const handlePublish = async () => {
-    if (!cloneData || !session) return;
+    if (!cloneData) return;
+    if (!session && !destSignerRef.current) return;
 
     setStep("publishing");
-    const relays = session.relays;
+    const destinationSigner = destSignerRef.current ?? undefined;
+    const relays = session?.relays ?? DEFAULT_RELAYS;
     const errors: Record<string, string> = {};
 
     // Profile
     if (selected.profile && cloneData.profile) {
       setPublishStatus((prev) => ({ ...prev, profile: "publishing" }));
       try {
-        await publishClonedProfile(cloneData.profile.rawContent, relays);
+        await publishClonedProfile(cloneData.profile.rawContent, relays, destinationSigner);
         setPublishStatus((prev) => ({ ...prev, profile: "success" }));
       } catch (error) {
         errors.profile = error instanceof Error ? error.message : "Failed";
@@ -213,6 +275,7 @@ export default function Clonable() {
           cloneData.followList,
           relays,
           cloneData.followListContent,
+          destinationSigner,
         );
         setPublishStatus((prev) => ({ ...prev, follows: "success" }));
       } catch (error) {
@@ -228,7 +291,7 @@ export default function Clonable() {
     if (selected.mutes && cloneData.muteList) {
       setPublishStatus((prev) => ({ ...prev, mutes: "publishing" }));
       try {
-        await publishClonedMutes(cloneData.muteList, relays);
+        await publishClonedMutes(cloneData.muteList, relays, destinationSigner);
         setPublishStatus((prev) => ({ ...prev, mutes: "success" }));
       } catch (error) {
         errors.mutes = error instanceof Error ? error.message : "Failed";
@@ -243,22 +306,131 @@ export default function Clonable() {
     if (selected.relays && cloneData.relayList) {
       setPublishStatus((prev) => ({ ...prev, relays: "publishing" }));
       try {
-        await publishClonedRelayList(cloneData.relayList, relays);
+        await publishClonedRelayList(cloneData.relayList, relays, destinationSigner);
         setPublishStatus((prev) => ({ ...prev, relays: "success" }));
       } catch (error) {
         errors.relays = error instanceof Error ? error.message : "Failed";
         setPublishStatus((prev) => ({ ...prev, relays: "error" }));
       }
+      await delay(500);
     } else {
       setPublishStatus((prev) => ({ ...prev, relays: "skipped" }));
     }
 
+    // Pinned Notes
+    if (selected.pinnedNotes && cloneData.pinnedNotes) {
+      setPublishStatus((prev) => ({ ...prev, pinnedNotes: "publishing" }));
+      try {
+        await publishClonedPinnedNotes(cloneData.pinnedNotes, relays, destinationSigner);
+        setPublishStatus((prev) => ({ ...prev, pinnedNotes: "success" }));
+      } catch (error) {
+        errors.pinnedNotes = error instanceof Error ? error.message : "Failed";
+        setPublishStatus((prev) => ({ ...prev, pinnedNotes: "error" }));
+      }
+      await delay(500);
+    } else {
+      setPublishStatus((prev) => ({ ...prev, pinnedNotes: "skipped" }));
+    }
+
+    // Bookmarks
+    if (selected.bookmarks && cloneData.bookmarks) {
+      setPublishStatus((prev) => ({ ...prev, bookmarks: "publishing" }));
+      try {
+        await publishClonedBookmarks(cloneData.bookmarks, relays, destinationSigner);
+        setPublishStatus((prev) => ({ ...prev, bookmarks: "success" }));
+      } catch (error) {
+        errors.bookmarks = error instanceof Error ? error.message : "Failed";
+        setPublishStatus((prev) => ({ ...prev, bookmarks: "error" }));
+      }
+      await delay(500);
+    } else {
+      setPublishStatus((prev) => ({ ...prev, bookmarks: "skipped" }));
+    }
+
+    // Communities
+    if (selected.communities && cloneData.communities) {
+      setPublishStatus((prev) => ({ ...prev, communities: "publishing" }));
+      try {
+        await publishClonedCommunities(cloneData.communities, relays, destinationSigner);
+        setPublishStatus((prev) => ({ ...prev, communities: "success" }));
+      } catch (error) {
+        errors.communities = error instanceof Error ? error.message : "Failed";
+        setPublishStatus((prev) => ({ ...prev, communities: "error" }));
+      }
+      await delay(500);
+    } else {
+      setPublishStatus((prev) => ({ ...prev, communities: "skipped" }));
+    }
+
+    // Search Relays
+    if (selected.searchRelays && cloneData.searchRelays) {
+      setPublishStatus((prev) => ({ ...prev, searchRelays: "publishing" }));
+      try {
+        await publishClonedSearchRelays(cloneData.searchRelays, relays, destinationSigner);
+        setPublishStatus((prev) => ({ ...prev, searchRelays: "success" }));
+      } catch (error) {
+        errors.searchRelays = error instanceof Error ? error.message : "Failed";
+        setPublishStatus((prev) => ({ ...prev, searchRelays: "error" }));
+      }
+      await delay(500);
+    } else {
+      setPublishStatus((prev) => ({ ...prev, searchRelays: "skipped" }));
+    }
+
+    // Interests
+    if (selected.interests && cloneData.interests) {
+      setPublishStatus((prev) => ({ ...prev, interests: "publishing" }));
+      try {
+        await publishClonedInterests(cloneData.interests, relays, destinationSigner);
+        setPublishStatus((prev) => ({ ...prev, interests: "success" }));
+      } catch (error) {
+        errors.interests = error instanceof Error ? error.message : "Failed";
+        setPublishStatus((prev) => ({ ...prev, interests: "error" }));
+      }
+      await delay(500);
+    } else {
+      setPublishStatus((prev) => ({ ...prev, interests: "skipped" }));
+    }
+
+    // Emoji Lists
+    if (selected.emojiLists && cloneData.emojiLists) {
+      setPublishStatus((prev) => ({ ...prev, emojiLists: "publishing" }));
+      try {
+        await publishClonedEmojiLists(cloneData.emojiLists, relays, destinationSigner);
+        setPublishStatus((prev) => ({ ...prev, emojiLists: "success" }));
+      } catch (error) {
+        errors.emojiLists = error instanceof Error ? error.message : "Failed";
+        setPublishStatus((prev) => ({ ...prev, emojiLists: "error" }));
+      }
+      await delay(500);
+    } else {
+      setPublishStatus((prev) => ({ ...prev, emojiLists: "skipped" }));
+    }
+
+    // DM Relays
+    if (selected.dmRelays && cloneData.dmRelays) {
+      setPublishStatus((prev) => ({ ...prev, dmRelays: "publishing" }));
+      try {
+        await publishClonedDmRelays(cloneData.dmRelays, relays, destinationSigner);
+        setPublishStatus((prev) => ({ ...prev, dmRelays: "success" }));
+      } catch (error) {
+        errors.dmRelays = error instanceof Error ? error.message : "Failed";
+        setPublishStatus((prev) => ({ ...prev, dmRelays: "error" }));
+      }
+    } else {
+      setPublishStatus((prev) => ({ ...prev, dmRelays: "skipped" }));
+    }
+
     setPublishErrors(errors);
 
-    // Destroy nsec signer
+    // Destroy signers
     if (nsecSignerRef.current) {
       nsecSignerRef.current.destroy();
       nsecSignerRef.current = null;
+    }
+    if (destSignerRef.current) {
+      destSignerRef.current.destroy();
+      destSignerRef.current = null;
     }
 
     setStep("done");
@@ -289,20 +461,96 @@ export default function Clonable() {
     (cloneData.profile ||
       (cloneData.followList && cloneData.followList.length > 0) ||
       (cloneData.muteList && totalMuteCount > 0) ||
-      (cloneData.relayList && totalRelayCount > 0));
+      (cloneData.relayList && totalRelayCount > 0) ||
+      cloneData.pinnedNotes ||
+      cloneData.bookmarks ||
+      cloneData.communities ||
+      cloneData.searchRelays ||
+      cloneData.interests ||
+      cloneData.emojiLists ||
+      cloneData.dmRelays);
 
   const hasAnythingSelected =
     (selected.profile && cloneData?.profile) ||
     (selected.follows && cloneData?.followList && cloneData.followList.length > 0) ||
     (selected.mutes && cloneData?.muteList && totalMuteCount > 0) ||
-    (selected.relays && cloneData?.relayList && totalRelayCount > 0);
+    (selected.relays && cloneData?.relayList && totalRelayCount > 0) ||
+    (selected.pinnedNotes && cloneData?.pinnedNotes) ||
+    (selected.bookmarks && cloneData?.bookmarks) ||
+    (selected.communities && cloneData?.communities) ||
+    (selected.searchRelays && cloneData?.searchRelays) ||
+    (selected.interests && cloneData?.interests) ||
+    (selected.emojiLists && cloneData?.emojiLists) ||
+    (selected.dmRelays && cloneData?.dmRelays);
 
-  if (!session) {
+  // When no session and no destination nsec confirmed, show dest nsec input
+  if (!session && !destPubkey) {
     return (
-      <div className="text-center py-12">
-        <p className="text-gray-500 dark:text-gray-400">
-          Please connect your account to use Clonable.
-        </p>
+      <div className="max-w-2xl mx-auto">
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-2">
+            <ClonableIcon className="w-8 h-8 text-red-600 dark:text-red-400" />
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Clonable
+            </h1>
+          </div>
+          <p className="text-gray-600 dark:text-gray-400">
+            Migrate your profile, follows, mutes, and relays from another account
+            to your current keyset. Useful when recovering from a compromised key.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          <div className="p-4 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+            <div className="flex items-start gap-3">
+              <AlertTriangle
+                size={20}
+                className="text-amber-600 dark:text-amber-400 mt-0.5 shrink-0"
+              />
+              <div className="text-sm text-amber-800 dark:text-amber-300">
+                <p className="font-semibold mb-1">Security Notice</p>
+                <p>
+                  Your destination nsec will be held in memory only during this
+                  operation and cleared immediately after. It is never stored or
+                  transmitted. Only enter your nsec if you trust this application.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Enter destination account nsec
+            </label>
+            <input
+              type="password"
+              value={destKeyInput}
+              onChange={(e) => {
+                setDestKeyInput(e.target.value);
+                setDestInputError(null);
+              }}
+              onKeyDown={(e) => e.key === "Enter" && handleDestNsec()}
+              placeholder="nsec1..."
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-red-500 focus:border-transparent font-mono text-sm"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            {destInputError && (
+              <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+                {destInputError}
+              </p>
+            )}
+          </div>
+
+          <button
+            onClick={handleDestNsec}
+            disabled={!destKeyInput.trim()}
+            className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-red-600 hover:bg-red-700 disabled:bg-gray-400 dark:disabled:bg-gray-600 text-white font-semibold transition-colors"
+          >
+            Confirm Destination
+            <ArrowRight size={20} />
+          </button>
+        </div>
       </div>
     );
   }
@@ -322,6 +570,19 @@ export default function Clonable() {
           to your current keyset. Useful when recovering from a compromised key.
         </p>
       </div>
+
+      {/* Destination account indicator (when using nsec instead of session) */}
+      {destPubkey && !session && (
+        <div className="flex items-center gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 mb-6">
+          <Key size={16} className="text-red-600 dark:text-red-400 shrink-0" />
+          <div className="min-w-0">
+            <p className="text-xs text-gray-500 dark:text-gray-400">Destination account</p>
+            <p className="text-sm font-mono text-gray-700 dark:text-gray-300 truncate">
+              {hexToNpub(destPubkey)}
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Step: Mode Selection */}
       {step === "mode" && (
@@ -707,6 +968,230 @@ export default function Clonable() {
                     </p>
                   </div>
                 </label>
+
+                {/* Pinned Notes */}
+                <label
+                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                    cloneData.pinnedNotes
+                      ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.pinnedNotes}
+                    disabled={!cloneData.pinnedNotes}
+                    onChange={(e) =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        pinnedNotes: e.target.checked,
+                      }))
+                    }
+                    className="w-5 h-5 rounded text-red-600 focus:ring-red-500"
+                  />
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      Pinned Notes
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {cloneData.pinnedNotes
+                        ? `${cloneData.pinnedNotes.tags.length} items`
+                        : "No pinned notes found"}
+                    </p>
+                  </div>
+                </label>
+
+                {/* Bookmarks */}
+                <label
+                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                    cloneData.bookmarks
+                      ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.bookmarks}
+                    disabled={!cloneData.bookmarks}
+                    onChange={(e) =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        bookmarks: e.target.checked,
+                      }))
+                    }
+                    className="w-5 h-5 rounded text-red-600 focus:ring-red-500"
+                  />
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      Bookmarks
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {cloneData.bookmarks
+                        ? `${cloneData.bookmarks.tags.length} items`
+                        : "No bookmarks found"}
+                    </p>
+                  </div>
+                </label>
+
+                {/* Communities */}
+                <label
+                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                    cloneData.communities
+                      ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.communities}
+                    disabled={!cloneData.communities}
+                    onChange={(e) =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        communities: e.target.checked,
+                      }))
+                    }
+                    className="w-5 h-5 rounded text-red-600 focus:ring-red-500"
+                  />
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      Communities
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {cloneData.communities
+                        ? `${cloneData.communities.tags.length} items`
+                        : "No communities found"}
+                    </p>
+                  </div>
+                </label>
+
+                {/* Search Relays */}
+                <label
+                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                    cloneData.searchRelays
+                      ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.searchRelays}
+                    disabled={!cloneData.searchRelays}
+                    onChange={(e) =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        searchRelays: e.target.checked,
+                      }))
+                    }
+                    className="w-5 h-5 rounded text-red-600 focus:ring-red-500"
+                  />
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      Search Relays
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {cloneData.searchRelays
+                        ? `${cloneData.searchRelays.tags.length} relays`
+                        : "No search relays found"}
+                    </p>
+                  </div>
+                </label>
+
+                {/* Interests */}
+                <label
+                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                    cloneData.interests
+                      ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.interests}
+                    disabled={!cloneData.interests}
+                    onChange={(e) =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        interests: e.target.checked,
+                      }))
+                    }
+                    className="w-5 h-5 rounded text-red-600 focus:ring-red-500"
+                  />
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      Interests
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {cloneData.interests
+                        ? `${cloneData.interests.tags.length} items`
+                        : "No interests found"}
+                    </p>
+                  </div>
+                </label>
+
+                {/* Emoji Lists */}
+                <label
+                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                    cloneData.emojiLists
+                      ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.emojiLists}
+                    disabled={!cloneData.emojiLists}
+                    onChange={(e) =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        emojiLists: e.target.checked,
+                      }))
+                    }
+                    className="w-5 h-5 rounded text-red-600 focus:ring-red-500"
+                  />
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      Emoji Lists
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {cloneData.emojiLists
+                        ? `${cloneData.emojiLists.tags.length} items`
+                        : "No emoji lists found"}
+                    </p>
+                  </div>
+                </label>
+
+                {/* DM Relays */}
+                <label
+                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                    cloneData.dmRelays
+                      ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.dmRelays}
+                    disabled={!cloneData.dmRelays}
+                    onChange={(e) =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        dmRelays: e.target.checked,
+                      }))
+                    }
+                    className="w-5 h-5 rounded text-red-600 focus:ring-red-500"
+                  />
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      DM Relays
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {cloneData.dmRelays
+                        ? `${cloneData.dmRelays.tags.length} relays`
+                        : "No DM relays found"}
+                    </p>
+                  </div>
+                </label>
               </div>
 
               {/* Clone button */}
@@ -747,6 +1232,41 @@ export default function Clonable() {
               status={publishStatus.relays}
               error={publishErrors.relays}
             />
+            <PublishRow
+              label="Pinned Notes"
+              status={publishStatus.pinnedNotes}
+              error={publishErrors.pinnedNotes}
+            />
+            <PublishRow
+              label="Bookmarks"
+              status={publishStatus.bookmarks}
+              error={publishErrors.bookmarks}
+            />
+            <PublishRow
+              label="Communities"
+              status={publishStatus.communities}
+              error={publishErrors.communities}
+            />
+            <PublishRow
+              label="Search Relays"
+              status={publishStatus.searchRelays}
+              error={publishErrors.searchRelays}
+            />
+            <PublishRow
+              label="Interests"
+              status={publishStatus.interests}
+              error={publishErrors.interests}
+            />
+            <PublishRow
+              label="Emoji Lists"
+              status={publishStatus.emojiLists}
+              error={publishErrors.emojiLists}
+            />
+            <PublishRow
+              label="DM Relays"
+              status={publishStatus.dmRelays}
+              error={publishErrors.dmRelays}
+            />
           </div>
 
           {step === "done" && (
@@ -777,7 +1297,7 @@ export default function Clonable() {
                 </div>
               )}
 
-              {mode === "nsec" && (
+              {(mode === "nsec" || destPubkey) && (
                 <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
                   <div className="flex items-center gap-2">
                     <Shield
@@ -785,7 +1305,11 @@ export default function Clonable() {
                       className="text-green-600 dark:text-green-400"
                     />
                     <p className="text-xs text-gray-600 dark:text-gray-400">
-                      The nsec has been cleared from memory.
+                      {mode === "nsec" && destPubkey
+                        ? "Both nsecs have been cleared from memory."
+                        : mode === "nsec"
+                          ? "The source nsec has been cleared from memory."
+                          : "The destination nsec has been cleared from memory."}
                     </p>
                   </div>
                 </div>

--- a/components/Clonable.tsx
+++ b/components/Clonable.tsx
@@ -550,6 +550,10 @@ export default function Clonable() {
             Confirm Destination
             <ArrowRight size={20} />
           </button>
+
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+            You can also sign in with a browser extension or remote signer for a smoother experience.
+          </p>
         </div>
       </div>
     );
@@ -821,9 +825,11 @@ export default function Clonable() {
                   Select data to clone
                 </h3>
 
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+
                 {/* Profile */}
                 <label
-                  className={`flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
+                  className={`sm:col-span-2 flex items-center gap-4 p-4 rounded-lg border transition-colors cursor-pointer ${
                     cloneData.profile
                       ? "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
                       : "border-gray-100 dark:border-gray-800 opacity-50 cursor-not-allowed"
@@ -1192,6 +1198,7 @@ export default function Clonable() {
                     </p>
                   </div>
                 </label>
+                </div>
               </div>
 
               {/* Clone button */}
@@ -1211,12 +1218,14 @@ export default function Clonable() {
       {/* Step: Publishing */}
       {(step === "publishing" || step === "done") && (
         <div className="space-y-6">
-          <div className="space-y-3">
-            <PublishRow
-              label="Profile"
-              status={publishStatus.profile}
-              error={publishErrors.profile}
-            />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="sm:col-span-2">
+              <PublishRow
+                label="Profile"
+                status={publishStatus.profile}
+                error={publishErrors.profile}
+              />
+            </div>
             <PublishRow
               label="Follow List"
               status={publishStatus.follows}

--- a/components/ClonableWrapper.tsx
+++ b/components/ClonableWrapper.tsx
@@ -169,7 +169,7 @@ export default function ClonableWrapper() {
 
                 <div className="flex items-center gap-3">
                   <span className="hidden md:inline text-sm text-gray-600 dark:text-gray-400">
-                    Sign in to use Clonable
+                    Sign in for more features
                   </span>
                   <Link
                     href="/"

--- a/lib/clonableService.ts
+++ b/lib/clonableService.ts
@@ -8,14 +8,28 @@ import {
   publishProfile,
   publishFollowList,
   publishMuteList,
+  muteListToTags,
   getExpandedRelayList,
   getPool,
   signEvent,
   DEFAULT_RELAYS,
 } from "./nostr";
-import { MuteList, Profile, RelayListMetadata, RELAY_LIST_KIND } from "@/types";
+import {
+  MuteList,
+  Profile,
+  RelayListMetadata,
+  RELAY_LIST_KIND,
+  MUTE_LIST_KIND,
+  FOLLOW_LIST_KIND,
+} from "@/types";
 import { NsecSigner } from "./signers/NsecSigner";
 import { extractTagReason, extractTagEventRef } from "@/lib/utils/nostrHelpers";
+
+export interface RawListEvent {
+  tags: string[][];
+  content: string;
+  kind: number;
+}
 
 export interface CloneableData {
   profile: { parsed: Profile; rawContent: Record<string, unknown> } | null;
@@ -24,6 +38,62 @@ export interface CloneableData {
   muteList: MuteList | null;
   muteListHasPrivate: boolean;
   relayList: RelayListMetadata | null;
+  pinnedNotes: RawListEvent | null;
+  bookmarks: RawListEvent | null;
+  communities: RawListEvent | null;
+  searchRelays: RawListEvent | null;
+  interests: RawListEvent | null;
+  emojiLists: RawListEvent | null;
+  dmRelays: RawListEvent | null;
+}
+
+/**
+ * Fetch a raw list event by kind for a given pubkey.
+ */
+async function fetchRawListEvent(
+  pubkey: string,
+  kind: number,
+  relays: string[],
+): Promise<RawListEvent | null> {
+  const pool = getPool();
+  const events = await pool.querySync(relays, {
+    kinds: [kind],
+    authors: [pubkey],
+    limit: 5,
+  });
+  if (events.length === 0) return null;
+  events.sort((a, b) => b.created_at - a.created_at);
+  const event = events[0];
+  return { tags: event.tags, content: event.content, kind: event.kind };
+}
+
+/**
+ * Publish a raw list event, optionally using a destination signer.
+ */
+async function publishClonedRawListEvent(
+  event: RawListEvent,
+  relays: string[],
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  const eventTemplate: EventTemplate = {
+    kind: event.kind,
+    tags: event.tags,
+    content: event.content,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+
+  const signedEvent = destinationSigner
+    ? await destinationSigner.signEvent(eventTemplate)
+    : await signEvent(eventTemplate);
+  const pool = getPool();
+
+  const publishPromise = Promise.any(pool.publish(relays, signedEvent));
+  const timeoutPromise = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("Publish timeout")), 15000),
+  );
+  await Promise.race([publishPromise, timeoutPromise]);
+
+  return signedEvent;
 }
 
 /**
@@ -41,11 +111,30 @@ export async function fetchSourceData(
     : DEFAULT_RELAYS;
 
   // Step 2: Fetch all other data in parallel using source relays
-  const [rawContent, profile, followEvent, muteEvent] = await Promise.all([
+  const [
+    rawContent,
+    profile,
+    followEvent,
+    muteEvent,
+    pinnedNotes,
+    bookmarks,
+    communities,
+    searchRelays,
+    interests,
+    emojiLists,
+    dmRelays,
+  ] = await Promise.all([
     fetchRawProfileContent(pubkey, sourceRelays),
     fetchProfile(pubkey, sourceRelays),
     fetchFollowList(pubkey, sourceRelays),
     fetchMuteList(pubkey, sourceRelays),
+    fetchRawListEvent(pubkey, 10001, sourceRelays),
+    fetchRawListEvent(pubkey, 10003, sourceRelays),
+    fetchRawListEvent(pubkey, 10004, sourceRelays),
+    fetchRawListEvent(pubkey, 10007, sourceRelays),
+    fetchRawListEvent(pubkey, 10015, sourceRelays),
+    fetchRawListEvent(pubkey, 10030, sourceRelays),
+    fetchRawListEvent(pubkey, 10050, sourceRelays),
   ]);
 
   // Parse profile
@@ -97,6 +186,13 @@ export async function fetchSourceData(
     muteList,
     muteListHasPrivate,
     relayList: relayResult.metadata,
+    pinnedNotes,
+    bookmarks,
+    communities,
+    searchRelays,
+    interests,
+    emojiLists,
+    dmRelays,
   };
 }
 
@@ -191,6 +287,7 @@ async function decryptPrivateMutesWithSigner(
 export async function publishClonedRelayList(
   relayData: RelayListMetadata,
   relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
 ): Promise<Event> {
   const tags: string[][] = [];
 
@@ -211,7 +308,9 @@ export async function publishClonedRelayList(
     created_at: Math.floor(Date.now() / 1000),
   };
 
-  const signedEvent = await signEvent(eventTemplate);
+  const signedEvent = destinationSigner
+    ? await destinationSigner.signEvent(eventTemplate)
+    : await signEvent(eventTemplate);
   const pool = getPool();
 
   const publishPromise = Promise.any(pool.publish(relays, signedEvent));
@@ -229,7 +328,30 @@ export async function publishClonedRelayList(
 export async function publishClonedProfile(
   rawContent: Record<string, unknown>,
   relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
 ): Promise<Event> {
+  if (destinationSigner) {
+    const cleanContent: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawContent)) {
+      if (value !== "" && value !== undefined && value !== null) {
+        cleanContent[key] = value;
+      }
+    }
+    const eventTemplate: EventTemplate = {
+      kind: 0,
+      tags: [],
+      content: JSON.stringify(cleanContent),
+      created_at: Math.floor(Date.now() / 1000),
+    };
+    const signedEvent = await destinationSigner.signEvent(eventTemplate);
+    const pool = getPool();
+    const publishPromise = Promise.any(pool.publish(relays, signedEvent));
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Publish timeout")), 15000),
+    );
+    await Promise.race([publishPromise, timeoutPromise]);
+    return signedEvent;
+  }
   return publishProfile({}, rawContent, relays);
 }
 
@@ -240,17 +362,130 @@ export async function publishClonedFollows(
   pubkeys: string[],
   relays: string[] = DEFAULT_RELAYS,
   content: string = "",
+  destinationSigner?: NsecSigner,
 ): Promise<Event> {
+  if (destinationSigner) {
+    const tags = pubkeys.map((pubkey) => ["p", pubkey]);
+    const eventTemplate: EventTemplate = {
+      kind: FOLLOW_LIST_KIND,
+      tags,
+      content,
+      created_at: Math.floor(Date.now() / 1000),
+    };
+    const signedEvent = await destinationSigner.signEvent(eventTemplate);
+    const pool = getPool();
+    const publishPromise = Promise.any(pool.publish(relays, signedEvent));
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Publish timeout")), 15000),
+    );
+    await Promise.race([publishPromise, timeoutPromise]);
+    return signedEvent;
+  }
   return publishFollowList(pubkeys, relays, content);
 }
 
 /**
  * Publish cloned mute list for the currently logged-in user.
- * Private items are re-encrypted using the logged-in signer.
+ * Private items are re-encrypted using the destination signer when provided.
  */
 export async function publishClonedMutes(
   muteList: MuteList,
   relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
 ): Promise<Event> {
+  if (destinationSigner) {
+    const destPubkey = await destinationSigner.getPublicKey();
+    const publicList: MuteList = {
+      pubkeys: muteList.pubkeys.filter((item) => !item.private),
+      words: muteList.words.filter((item) => !item.private),
+      tags: muteList.tags.filter((item) => !item.private),
+      threads: muteList.threads.filter((item) => !item.private),
+    };
+    const privateList: MuteList = {
+      pubkeys: muteList.pubkeys.filter((item) => item.private),
+      words: muteList.words.filter((item) => item.private),
+      tags: muteList.tags.filter((item) => item.private),
+      threads: muteList.threads.filter((item) => item.private),
+    };
+    const tags = muteListToTags(publicList);
+    const privateTags = muteListToTags(privateList);
+    let encryptedContent = "";
+    if (privateTags.length > 0) {
+      encryptedContent = await destinationSigner.nip04Encrypt(
+        destPubkey,
+        JSON.stringify(privateTags),
+      );
+    }
+    const eventTemplate: EventTemplate = {
+      kind: MUTE_LIST_KIND,
+      tags,
+      content: encryptedContent,
+      created_at: Math.floor(Date.now() / 1000),
+    };
+    const signedEvent = await destinationSigner.signEvent(eventTemplate);
+    const pool = getPool();
+    const publishPromise = Promise.any(pool.publish(relays, signedEvent));
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Publish timeout")), 15000),
+    );
+    await Promise.race([publishPromise, timeoutPromise]);
+    return signedEvent;
+  }
   return publishMuteList(muteList, relays);
+}
+
+export async function publishClonedPinnedNotes(
+  event: RawListEvent,
+  relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  return publishClonedRawListEvent(event, relays, destinationSigner);
+}
+
+export async function publishClonedBookmarks(
+  event: RawListEvent,
+  relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  return publishClonedRawListEvent(event, relays, destinationSigner);
+}
+
+export async function publishClonedCommunities(
+  event: RawListEvent,
+  relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  return publishClonedRawListEvent(event, relays, destinationSigner);
+}
+
+export async function publishClonedSearchRelays(
+  event: RawListEvent,
+  relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  return publishClonedRawListEvent(event, relays, destinationSigner);
+}
+
+export async function publishClonedInterests(
+  event: RawListEvent,
+  relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  return publishClonedRawListEvent(event, relays, destinationSigner);
+}
+
+export async function publishClonedEmojiLists(
+  event: RawListEvent,
+  relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  return publishClonedRawListEvent(event, relays, destinationSigner);
+}
+
+export async function publishClonedDmRelays(
+  event: RawListEvent,
+  relays: string[] = DEFAULT_RELAYS,
+  destinationSigner?: NsecSigner,
+): Promise<Event> {
+  return publishClonedRawListEvent(event, relays, destinationSigner);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/types/index.ts
+++ b/types/index.ts
@@ -85,9 +85,16 @@ export type AuthState = "disconnected" | "connecting" | "connected" | "error";
 // - Private items are encrypted in the 'content' field using NIP-44
 // - A single event can contain both public and private mutes
 export const MUTE_LIST_KIND = 10000; // Mute list (NIP-51) - can have public tags AND encrypted content
+export const PINNED_NOTES_KIND = 10001; // Pinned Notes (NIP-51)
+export const RELAY_LIST_KIND = 10002; // NIP-65: Relay List Metadata
+export const BOOKMARKS_KIND = 10003; // Bookmarks (NIP-51)
+export const COMMUNITIES_KIND = 10004; // Communities (NIP-51)
+export const SEARCH_RELAYS_KIND = 10007; // Search Relays (NIP-51)
+export const INTERESTS_KIND = 10015; // Interests (NIP-51)
+export const EMOJI_LISTS_KIND = 10030; // Emoji Lists (NIP-51)
+export const DM_RELAYS_KIND = 10050; // DM Relays (NIP-51)
 export const PUBLIC_LIST_KIND = 30001; // Generic public lists (deprecated for mutes)
 export const FOLLOW_LIST_KIND = 3;
-export const RELAY_LIST_KIND = 10002; // NIP-65: Relay List Metadata
 
 // Type guards
 export function isMutedPubkey(item: MuteItem): item is MutedPubkey {


### PR DESCRIPTION
## What this does

Expands the Clonable feature in two ways:

### Part 1 — 7 new event kinds

Brings Clonable up to parity with SyncStr by adding support for:

| Kind | Data |
|------|------|
| 10001 | Pinned Notes |
| 10003 | Bookmarks |
| 10004 | Communities |
| 10007 | Search Relays |
| 10015 | Interests |
| 10030 | Emoji Lists |
| 10050 | DM Relays |

All 7 are fetched in parallel alongside the existing 4 in `fetchSourceData`. A generic `RawListEvent` type + `fetchRawListEvent`/`publishClonedRawListEvent` helpers keep the service layer clean. Named publish exports added for each kind.

### Part 2 — nsec destination login

Previously Clonable required an active NIP-07/46 session and showed a dead-end message if none existed. Now:

- When no session is detected, a destination nsec input form is shown instead (with security notice)
- Derived pubkey is displayed after validation so the user can confirm they entered the right key
- `destSignerRef` (NsecSigner) is threaded through all `publishCloned*` functions as an optional param
- Both source and destination nsec refs are destroyed after publish and on reset

### Files changed
- `lib/clonableService.ts`
- `components/Clonable.tsx`
- `types/index.ts`