### PR TITLE
feat: NIP-44 mute list encryption + default privacy preference

### DIFF
--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -62,13 +62,13 @@ export default function OnboardingModal({ onClose, onCreateBackup, onSkip }: Onb
                   <div className="flex items-start gap-2">
                     <Eye className="text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" size={14} />
                     <div className="text-xs text-indigo-800 dark:text-indigo-200">
-                      <strong>Public (Recommended):</strong> Stored in event tags, visible to anyone. Works in ALL Nostr clients (Damus, Primal, Amethyst, etc.).
+                      <strong>Public (Recommended):</strong> Stored in event tags, visible to anyone. Works in all Nostr clients.
                     </div>
                   </div>
                   <div className="flex items-start gap-2">
                     <EyeOff className="text-orange-600 dark:text-orange-400 flex-shrink-0 mt-0.5" size={14} />
                     <div className="text-xs text-indigo-800 dark:text-indigo-200">
-                      <strong>Private (Limited Compatibility):</strong> Encrypted in the content field. Only works in some clients (Primal, Amethyst). Damus and others don&apos;t decrypt them.
+                      <strong>Private (Limited Compatibility):</strong> Encrypted in the content field using NIP-44 (per NIP-51 spec). Works in clients that support NIP-44 decryption.
                     </div>
                   </div>
                 </div>

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -68,7 +68,7 @@ export default function OnboardingModal({ onClose, onCreateBackup, onSkip }: Onb
                   <div className="flex items-start gap-2">
                     <EyeOff className="text-orange-600 dark:text-orange-400 flex-shrink-0 mt-0.5" size={14} />
                     <div className="text-xs text-indigo-800 dark:text-indigo-200">
-                      <strong>Private (Limited Compatibility):</strong> Encrypted in the content field using NIP-44 (per NIP-51 spec). Works in clients that support NIP-44 decryption.
+                      <strong>Private (Limited Compatibility):</strong> Encrypted with NIP-44 per the NIP-51 spec. Not all clients support this yet — if yours doesn&apos;t, ask its developers to adopt NIP-51.
                     </div>
                   </div>
                 </div>

--- a/components/PrivacyControls.tsx
+++ b/components/PrivacyControls.tsx
@@ -65,11 +65,11 @@ export default function PrivacyControls() {
               <div className="space-y-2">
                 <p><strong>Public:</strong> Stored in event tags, visible to everyone. Works in all clients.</p>
 
-                <p><strong>Private:</strong> Encrypted using NIP-04. Works in Primal and Amethyst, but not Damus.</p>
+                <p><strong>Private:</strong> Encrypted using NIP-44 (per NIP-51 spec). Supported by clients that implement NIP-44 decryption. Legacy NIP-04 encrypted mutes are also read for backward compatibility.</p>
 
                 <p className="text-amber-800 dark:text-amber-300"><strong>⚠️ Warning:</strong> Other clients may overwrite and delete all private mutes. Only manage private mutes through Mutable.</p>
 
-                <p className="text-blue-900 dark:text-blue-100"><strong>💡 Recommendation:</strong> Use public mutes for compatibility across all clients. Private mutes offer less compatibility.</p>
+                <p className="text-blue-900 dark:text-blue-100"><strong>💡 Recommendation:</strong> Use public mutes for maximum compatibility across all clients. Private mutes require NIP-44 support in the client.</p>
               </div>
 
               <p className="text-xs text-gray-600 dark:text-gray-400">
@@ -154,7 +154,7 @@ export default function PrivacyControls() {
 
       <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
         <p className="text-xs text-gray-600 dark:text-gray-400">
-          <strong>Recommendation:</strong> Keep mutes <strong>public</strong> if you use multiple Nostr clients (Damus, Primal, etc.) to ensure mutes work everywhere. Only use private mute lists for extra privacy and understand they won&apos;t work in every client.
+          <strong>Recommendation:</strong> Keep mutes <strong>public</strong> if you use multiple Nostr clients to ensure mutes work everywhere. Private mutes use NIP-44 encryption (per NIP-51) and require client support to decrypt.
         </p>
       </div>
     </div>

--- a/components/PrivacyControls.tsx
+++ b/components/PrivacyControls.tsx
@@ -153,17 +153,18 @@ export default function PrivacyControls() {
       </div>
 
       <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-medium text-gray-900 dark:text-white">Default privacy for new mutes</p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              {defaultMutePrivacy ? "New mutes will be private (encrypted)" : "New mutes will be public (visible)"}
-            </p>
-          </div>
+        <p className="text-sm font-medium text-gray-900 dark:text-white mb-1">Default privacy for new mutes</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+          {defaultMutePrivacy ? "New mutes will be private (encrypted)" : "New mutes will be public (visible)"}
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <span className={`text-xs font-medium ${!defaultMutePrivacy ? "text-amber-600 dark:text-amber-400" : "text-gray-400 dark:text-gray-500"}`}>
+            Public
+          </span>
           <button
             onClick={() => setDefaultMutePrivacy(!defaultMutePrivacy)}
             className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              defaultMutePrivacy ? "bg-purple-600" : "bg-gray-300 dark:bg-gray-600"
+              defaultMutePrivacy ? "bg-purple-600" : "bg-amber-500"
             }`}
           >
             <span
@@ -172,6 +173,9 @@ export default function PrivacyControls() {
               }`}
             />
           </button>
+          <span className={`text-xs font-medium ${defaultMutePrivacy ? "text-purple-600 dark:text-purple-400" : "text-gray-400 dark:text-gray-500"}`}>
+            Private
+          </span>
         </div>
       </div>
 

--- a/components/PrivacyControls.tsx
+++ b/components/PrivacyControls.tsx
@@ -5,7 +5,7 @@ import { useStore } from '@/lib/store';
 import { Lock, Unlock, Eye, EyeOff, Info, AlertCircle } from 'lucide-react';
 
 export default function PrivacyControls() {
-  const { muteList, bulkSetPrivacy } = useStore();
+  const { muteList, bulkSetPrivacy, defaultMutePrivacy, setDefaultMutePrivacy } = useStore();
   const [showInfo, setShowInfo] = useState(true); // Default to visible
 
   const publicPubkeys = muteList.pubkeys.filter(item => !item.private).length;
@@ -152,7 +152,30 @@ export default function PrivacyControls() {
         </div>
       </div>
 
-      <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+      <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-900 dark:text-white">Default privacy for new mutes</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {defaultMutePrivacy ? "New mutes will be private (encrypted)" : "New mutes will be public (visible)"}
+            </p>
+          </div>
+          <button
+            onClick={() => setDefaultMutePrivacy(!defaultMutePrivacy)}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+              defaultMutePrivacy ? "bg-purple-600" : "bg-gray-300 dark:bg-gray-600"
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                defaultMutePrivacy ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
         <p className="text-xs text-gray-600 dark:text-gray-400">
           <strong>Recommendation:</strong> Keep mutes <strong>public</strong> if you use multiple Nostr clients to ensure mutes work everywhere. Private mutes use NIP-44 encryption per the NIP-51 spec, but not all clients support this yet.
         </p>

--- a/components/PrivacyControls.tsx
+++ b/components/PrivacyControls.tsx
@@ -65,11 +65,11 @@ export default function PrivacyControls() {
               <div className="space-y-2">
                 <p><strong>Public:</strong> Stored in event tags, visible to everyone. Works in all clients.</p>
 
-                <p><strong>Private:</strong> Encrypted using NIP-44 (per NIP-51 spec). Supported by clients that implement NIP-44 decryption. Legacy NIP-04 encrypted mutes are also read for backward compatibility.</p>
+                <p><strong>Private:</strong> Encrypted using NIP-44 as required by the NIP-51 spec. Mutable also reads legacy NIP-04 encrypted mutes for backward compatibility.</p>
 
-                <p className="text-amber-800 dark:text-amber-300"><strong>⚠️ Warning:</strong> Other clients may overwrite and delete all private mutes. Only manage private mutes through Mutable.</p>
+                <p className="text-amber-800 dark:text-amber-300"><strong>⚠️ Compatibility:</strong> Not all clients support private mutes consistently. Some may silently overwrite or drop them. Jumble currently uses the older NIP-04 encryption, while Primal does not encrypt private mutes at all. If your favorite client doesn&apos;t handle private mutes correctly, encourage its developers to follow the NIP-51 spec.</p>
 
-                <p className="text-blue-900 dark:text-blue-100"><strong>💡 Recommendation:</strong> Use public mutes for maximum compatibility across all clients. Private mutes require NIP-44 support in the client.</p>
+                <p className="text-blue-900 dark:text-blue-100"><strong>💡 Recommendation:</strong> Use public mutes for maximum compatibility. Only use private mutes if you understand the cross-client limitations.</p>
               </div>
 
               <p className="text-xs text-gray-600 dark:text-gray-400">
@@ -154,7 +154,7 @@ export default function PrivacyControls() {
 
       <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
         <p className="text-xs text-gray-600 dark:text-gray-400">
-          <strong>Recommendation:</strong> Keep mutes <strong>public</strong> if you use multiple Nostr clients to ensure mutes work everywhere. Private mutes use NIP-44 encryption (per NIP-51) and require client support to decrypt.
+          <strong>Recommendation:</strong> Keep mutes <strong>public</strong> if you use multiple Nostr clients to ensure mutes work everywhere. Private mutes use NIP-44 encryption per the NIP-51 spec, but not all clients support this yet.
         </p>
       </div>
     </div>

--- a/components/Purgatory.tsx
+++ b/components/Purgatory.tsx
@@ -62,6 +62,7 @@ export default function Purgatory() {
     addMutedItem,
     removeMutedItem,
     setHasUnsavedChanges,
+    defaultMutePrivacy,
   } = useStore();
 
   // Mode selection
@@ -273,7 +274,7 @@ export default function Purgatory() {
         type: "pubkey" as const,
         value: pubkey,
         reason,
-        private: false,
+        private: defaultMutePrivacy,
       };
     });
 

--- a/components/Reciprocals.tsx
+++ b/components/Reciprocals.tsx
@@ -337,7 +337,6 @@ export default function Reciprocals() {
             type: "pubkey",
             value: result.pubkey,
             reason: "Non-reciprocal follow",
-            private: false,
           },
           "pubkeys",
         );
@@ -406,7 +405,6 @@ export default function Reciprocals() {
         type: "pubkey",
         value: pubkey,
         reason: "Non-reciprocal follow",
-        private: false,
       },
       "pubkeys",
     );

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -36,13 +36,15 @@ import {
   Download,
   Upload,
   User,
+  Lock,
+  Unlock,
 } from "lucide-react";
 
 export default function Settings() {
   const router = useRouter();
   const { disconnect } = useAuth();
   const { triggerSync, getSyncStatus, isOnline } = useRelaySync();
-  const { session, setHasCompletedOnboarding } = useStore();
+  const { session, setHasCompletedOnboarding, defaultMutePrivacy, setDefaultMutePrivacy } = useStore();
 
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [resetStep, setResetStep] = useState(0);
@@ -997,6 +999,46 @@ export default function Settings() {
               </div>
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* Mute Privacy Default */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center gap-3 mb-4">
+          {defaultMutePrivacy ? <Lock size={24} className="text-purple-600 dark:text-purple-400" /> : <Unlock size={24} className="text-amber-600 dark:text-amber-400" />}
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+            Mute Privacy
+          </h2>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+            <div className="flex-1">
+              <h3 className="font-semibold text-gray-900 dark:text-white">
+                Default privacy for new mutes
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {defaultMutePrivacy
+                  ? "New mutes will be private (encrypted with NIP-44)"
+                  : "New mutes will be public (visible to everyone)"}
+              </p>
+            </div>
+            <button
+              onClick={() => setDefaultMutePrivacy(!defaultMutePrivacy)}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                defaultMutePrivacy ? "bg-purple-600" : "bg-gray-300 dark:bg-gray-600"
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                  defaultMutePrivacy ? "translate-x-6" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Public mutes are more compatible across Nostr clients. Private mutes use NIP-44 encryption per the NIP-51 spec, but not all clients support this yet. You can always change individual items using the lock icon.
+          </p>
         </div>
       </div>
 

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1012,29 +1012,35 @@ export default function Settings() {
         </div>
 
         <div className="space-y-4">
-          <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-            <div className="flex-1">
-              <h3 className="font-semibold text-gray-900 dark:text-white">
-                Default privacy for new mutes
-              </h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
-                {defaultMutePrivacy
-                  ? "New mutes will be private (encrypted with NIP-44)"
-                  : "New mutes will be public (visible to everyone)"}
-              </p>
-            </div>
-            <button
-              onClick={() => setDefaultMutePrivacy(!defaultMutePrivacy)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                defaultMutePrivacy ? "bg-purple-600" : "bg-gray-300 dark:bg-gray-600"
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                  defaultMutePrivacy ? "translate-x-6" : "translate-x-1"
+          <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+            <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
+              Default privacy for new mutes
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+              {defaultMutePrivacy
+                ? "New mutes will be private (encrypted with NIP-44)"
+                : "New mutes will be public (visible to everyone)"}
+            </p>
+            <div className="flex items-center justify-center gap-3">
+              <span className={`text-sm font-medium ${!defaultMutePrivacy ? "text-amber-600 dark:text-amber-400" : "text-gray-400 dark:text-gray-500"}`}>
+                Public
+              </span>
+              <button
+                onClick={() => setDefaultMutePrivacy(!defaultMutePrivacy)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  defaultMutePrivacy ? "bg-purple-600" : "bg-amber-500"
                 }`}
-              />
-            </button>
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    defaultMutePrivacy ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+              <span className={`text-sm font-medium ${defaultMutePrivacy ? "text-purple-600 dark:text-purple-400" : "text-gray-400 dark:text-gray-500"}`}>
+                Private
+              </span>
+            </div>
           </div>
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Public mutes are more compatible across Nostr clients. Private mutes use NIP-44 encryption per the NIP-51 spec, but not all clients support this yet. You can always change individual items using the lock icon.

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -45,6 +45,8 @@ import {
   ShieldCheck,
   Edit2,
   Save,
+  Eye,
+  EyeOff,
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
@@ -66,6 +68,7 @@ export default function UserProfileModal({
     updateMutedItem,
     hasUnsavedChanges,
     setHasUnsavedChanges,
+    defaultMutePrivacy,
   } = useStore();
   const {
     addProtection: addProtectionToRelay,
@@ -95,6 +98,7 @@ export default function UserProfileModal({
   const [isProtected, setIsProtected] = useState(false);
   const [showReasonInput, setShowReasonInput] = useState(false);
   const [muteReason, setMuteReason] = useState("");
+  const [mutePrivate, setMutePrivate] = useState(defaultMutePrivacy);
   const [muteEventRef, setMuteEventRef] = useState("");
   const [muteEventRefError, setMuteEventRefError] = useState<string | null>(
     null,
@@ -216,11 +220,13 @@ export default function UserProfileModal({
         value: profile.pubkey,
         reason: reason || undefined,
         eventRef,
+        private: mutePrivate,
       },
       "pubkeys",
     );
     setShowReasonInput(false);
     setMuteReason("");
+    setMutePrivate(defaultMutePrivacy);
     setMuteEventRef("");
     setMuteEventRefError(null);
   };
@@ -619,6 +625,26 @@ export default function UserProfileModal({
                     {muteEventRefError}
                   </p>
                 )}
+                <div className="flex items-center justify-center gap-3 p-2 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                  <span className={`text-xs font-medium ${!mutePrivate ? "text-amber-600 dark:text-amber-400" : "text-gray-400 dark:text-gray-500"}`}>
+                    Public
+                  </span>
+                  <button
+                    onClick={() => setMutePrivate(!mutePrivate)}
+                    className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                      mutePrivate ? "bg-purple-600" : "bg-amber-500"
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
+                        mutePrivate ? "translate-x-5" : "translate-x-1"
+                      }`}
+                    />
+                  </button>
+                  <span className={`text-xs font-medium ${mutePrivate ? "text-purple-600 dark:text-purple-400" : "text-gray-400 dark:text-gray-500"}`}>
+                    Private
+                  </span>
+                </div>
                 <div className="flex gap-2">
                   <button
                     onClick={() => handleMute(muteReason)}

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -327,9 +327,11 @@ export async function fetchMuteList(
 }
 
 // Decrypt private mutes from content field using the active signer
+// Supports both NIP-44 (modern) and NIP-04 (legacy) based on encryption tag hint
 async function decryptPrivateMutes(
   encryptedContent: string,
   authorPubkey: string,
+  encMethod?: "nip44" | "nip04",
 ): Promise<MuteList> {
   const privateMutes: MuteList = {
     pubkeys: [],
@@ -350,8 +352,32 @@ async function decryptPrivateMutes(
       return privateMutes;
     }
 
-    // NIP-04 decryption via signer
-    const decrypted = await signer.nip04Decrypt(authorPubkey, encryptedContent);
+    // Decrypt using the appropriate method based on the encryption tag
+    // If no tag (legacy events), try NIP-44 first then fall back to NIP-04
+    let decrypted: string;
+    if (encMethod === "nip04") {
+      // Explicitly tagged as NIP-04
+      decrypted = await signer.nip04Decrypt(authorPubkey, encryptedContent);
+    } else if (encMethod === "nip44") {
+      // Explicitly tagged as NIP-44
+      if (!signer.nip44Decrypt) {
+        throw new Error(
+          "Private mutes were encrypted with NIP-44 but current signer doesn't support nip44Decrypt.",
+        );
+      }
+      decrypted = await signer.nip44Decrypt(authorPubkey, encryptedContent);
+    } else {
+      // No encryption tag (legacy event) — try NIP-44 first, fall back to NIP-04
+      if (signer.nip44Decrypt) {
+        try {
+          decrypted = await signer.nip44Decrypt(authorPubkey, encryptedContent);
+        } catch {
+          decrypted = await signer.nip04Decrypt(authorPubkey, encryptedContent);
+        }
+      } else {
+        decrypted = await signer.nip04Decrypt(authorPubkey, encryptedContent);
+      }
+    }
 
     if (!decrypted || !decrypted.trim()) {
       return privateMutes;
@@ -484,9 +510,16 @@ export async function parseMuteListEvent(
   // Parse private mutes from encrypted content (if any)
   if (event.content && event.content.trim() !== "") {
     try {
+      // Check for encryption method tag to determine which cipher was used
+      const encTag = event.tags.find((t) => t[0] === "encryption");
+      const encMethod = encTag?.[1] === "nip44" || encTag?.[1] === "nip04"
+        ? (encTag[1] as "nip44" | "nip04")
+        : undefined;
+
       const privateMutes = await decryptPrivateMutes(
         event.content,
         event.pubkey,
+        encMethod,
       );
       muteList.pubkeys.push(...privateMutes.pubkeys);
       muteList.words.push(...privateMutes.words);
@@ -577,26 +610,35 @@ export function muteListToTags(muteList: MuteList): string[][] {
 }
 
 // Encrypt private mutes for content field using the active signer
+// Prefers NIP-44 (modern, spec-correct per NIP-51) with fallback to NIP-04
 async function encryptPrivateMutes(
   privateList: MuteList,
   recipientPubkey: string,
-): Promise<string> {
+): Promise<{ encrypted: string; encMethod: "nip44" | "nip04" }> {
   const privateTags = muteListToTags(privateList);
 
   if (privateTags.length === 0) {
-    return "";
+    return { encrypted: "", encMethod: "nip44" };
   }
 
   try {
     // Get the active signer for encryption
     const signer = getSigner();
+    const plaintext = JSON.stringify(privateTags);
 
-    // NIP-04 encryption via signer (encrypt to yourself)
-    const encrypted = await signer.nip04Encrypt(
-      recipientPubkey,
-      JSON.stringify(privateTags),
-    );
-    return encrypted;
+    // Try NIP-44 first (modern, spec-correct per NIP-51, better supported by NIP-46 bunkers)
+    if (signer.nip44Encrypt) {
+      try {
+        const encrypted = await signer.nip44Encrypt(recipientPubkey, plaintext);
+        return { encrypted, encMethod: "nip44" };
+      } catch (error) {
+        console.warn("NIP-44 encrypt failed, falling back to NIP-04:", error);
+      }
+    }
+
+    // Fallback to NIP-04
+    const encrypted = await signer.nip04Encrypt(recipientPubkey, plaintext);
+    return { encrypted, encMethod: "nip04" };
   } catch (error) {
     console.error("Failed to encrypt private mutes:", error);
     throw new Error(
@@ -639,8 +681,16 @@ export async function publishMuteList(
   // Convert public items to tags
   const tags = muteListToTags(publicList);
 
-  // Encrypt private items for content field
-  const encryptedContent = await encryptPrivateMutes(privateList, userPubkey);
+  // Encrypt private items for content field (prefers NIP-44, falls back to NIP-04)
+  const { encrypted: encryptedContent, encMethod } = await encryptPrivateMutes(
+    privateList,
+    userPubkey,
+  );
+
+  // Add encryption method tag so decryption knows which cipher was used
+  if (encryptedContent) {
+    tags.push(["encryption", encMethod]);
+  }
 
   const eventTemplate: EventTemplate = {
     kind: MUTE_LIST_KIND,

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -327,11 +327,10 @@ export async function fetchMuteList(
 }
 
 // Decrypt private mutes from content field using the active signer
-// Supports both NIP-44 (modern) and NIP-04 (legacy) based on encryption tag hint
+// Per NIP-51: detect NIP-04 vs NIP-44 by checking for "?iv=" in the ciphertext
 async function decryptPrivateMutes(
   encryptedContent: string,
   authorPubkey: string,
-  encMethod?: "nip44" | "nip04",
 ): Promise<MuteList> {
   const privateMutes: MuteList = {
     pubkeys: [],
@@ -352,31 +351,20 @@ async function decryptPrivateMutes(
       return privateMutes;
     }
 
-    // Decrypt using the appropriate method based on the encryption tag
-    // If no tag (legacy events), try NIP-44 first then fall back to NIP-04
+    // Per NIP-51 spec: detect cipher by searching for "?iv=" in ciphertext.
+    // NIP-04 ciphertexts end with "?iv=<base64>", NIP-44 do not.
+    const isNip04 = encryptedContent.includes("?iv=");
+
     let decrypted: string;
-    if (encMethod === "nip04") {
-      // Explicitly tagged as NIP-04
+    if (isNip04) {
       decrypted = await signer.nip04Decrypt(authorPubkey, encryptedContent);
-    } else if (encMethod === "nip44") {
-      // Explicitly tagged as NIP-44
+    } else {
       if (!signer.nip44Decrypt) {
         throw new Error(
-          "Private mutes were encrypted with NIP-44 but current signer doesn't support nip44Decrypt.",
+          "Private mutes use NIP-44 encryption but your signer doesn't support NIP-44 decryption.",
         );
       }
       decrypted = await signer.nip44Decrypt(authorPubkey, encryptedContent);
-    } else {
-      // No encryption tag (legacy event) — try NIP-44 first, fall back to NIP-04
-      if (signer.nip44Decrypt) {
-        try {
-          decrypted = await signer.nip44Decrypt(authorPubkey, encryptedContent);
-        } catch {
-          decrypted = await signer.nip04Decrypt(authorPubkey, encryptedContent);
-        }
-      } else {
-        decrypted = await signer.nip04Decrypt(authorPubkey, encryptedContent);
-      }
     }
 
     if (!decrypted || !decrypted.trim()) {
@@ -510,16 +498,9 @@ export async function parseMuteListEvent(
   // Parse private mutes from encrypted content (if any)
   if (event.content && event.content.trim() !== "") {
     try {
-      // Check for encryption method tag to determine which cipher was used
-      const encTag = event.tags.find((t) => t[0] === "encryption");
-      const encMethod = encTag?.[1] === "nip44" || encTag?.[1] === "nip04"
-        ? (encTag[1] as "nip44" | "nip04")
-        : undefined;
-
       const privateMutes = await decryptPrivateMutes(
         event.content,
         event.pubkey,
-        encMethod,
       );
       muteList.pubkeys.push(...privateMutes.pubkeys);
       muteList.words.push(...privateMutes.words);
@@ -610,35 +591,32 @@ export function muteListToTags(muteList: MuteList): string[][] {
 }
 
 // Encrypt private mutes for content field using the active signer
-// Prefers NIP-44 (modern, spec-correct per NIP-51) with fallback to NIP-04
+// Per NIP-51: uses NIP-44 (spec-correct), falls back to NIP-04 if signer lacks NIP-44
 async function encryptPrivateMutes(
   privateList: MuteList,
   recipientPubkey: string,
-): Promise<{ encrypted: string; encMethod: "nip44" | "nip04" }> {
+): Promise<string> {
   const privateTags = muteListToTags(privateList);
 
   if (privateTags.length === 0) {
-    return { encrypted: "", encMethod: "nip44" };
+    return "";
   }
 
   try {
-    // Get the active signer for encryption
     const signer = getSigner();
     const plaintext = JSON.stringify(privateTags);
 
-    // Try NIP-44 first (modern, spec-correct per NIP-51, better supported by NIP-46 bunkers)
+    // NIP-44 preferred (spec-correct per NIP-51)
     if (signer.nip44Encrypt) {
       try {
-        const encrypted = await signer.nip44Encrypt(recipientPubkey, plaintext);
-        return { encrypted, encMethod: "nip44" };
+        return await signer.nip44Encrypt(recipientPubkey, plaintext);
       } catch (error) {
         console.warn("NIP-44 encrypt failed, falling back to NIP-04:", error);
       }
     }
 
-    // Fallback to NIP-04
-    const encrypted = await signer.nip04Encrypt(recipientPubkey, plaintext);
-    return { encrypted, encMethod: "nip04" };
+    // Fallback to NIP-04 (legacy, produces ciphertext with "?iv=" for auto-detection)
+    return await signer.nip04Encrypt(recipientPubkey, plaintext);
   } catch (error) {
     console.error("Failed to encrypt private mutes:", error);
     throw new Error(
@@ -681,16 +659,8 @@ export async function publishMuteList(
   // Convert public items to tags
   const tags = muteListToTags(publicList);
 
-  // Encrypt private items for content field (prefers NIP-44, falls back to NIP-04)
-  const { encrypted: encryptedContent, encMethod } = await encryptPrivateMutes(
-    privateList,
-    userPubkey,
-  );
-
-  // Add encryption method tag so decryption knows which cipher was used
-  if (encryptedContent) {
-    tags.push(["encryption", encMethod]);
-  }
+  // Encrypt private items for content field (NIP-44 per spec, NIP-04 fallback)
+  const encryptedContent = await encryptPrivateMutes(privateList, userPubkey);
 
   const eventTemplate: EventTemplate = {
     kind: MUTE_LIST_KIND,

--- a/lib/signers/NsecSigner.ts
+++ b/lib/signers/NsecSigner.ts
@@ -5,6 +5,7 @@ import {
   finalizeEvent,
   nip04,
   nip19,
+  nip44,
 } from "nostr-tools";
 import { Signer } from "./types";
 
@@ -45,6 +46,22 @@ export class NsecSigner implements Signer {
 
   async nip04Decrypt(pubkey: string, ciphertext: string): Promise<string> {
     return nip04.decrypt(this.secretKey, pubkey, ciphertext);
+  }
+
+  async nip44Encrypt(pubkey: string, plaintext: string): Promise<string> {
+    const conversationKey = nip44.v2.utils.getConversationKey(
+      this.secretKey,
+      pubkey,
+    );
+    return nip44.v2.encrypt(plaintext, conversationKey);
+  }
+
+  async nip44Decrypt(pubkey: string, ciphertext: string): Promise<string> {
+    const conversationKey = nip44.v2.utils.getConversationKey(
+      this.secretKey,
+      pubkey,
+    );
+    return nip44.v2.decrypt(ciphertext, conversationKey);
   }
 
   /**

--- a/lib/signers/types.ts
+++ b/lib/signers/types.ts
@@ -4,9 +4,10 @@ import { EventTemplate, VerifiedEvent } from "nostr-tools";
  * Extended Signer interface that includes encryption methods
  * needed for private mute list and relay storage encryption.
  *
- * NIP-04 methods are required (used for kind 10000 private mute lists).
- * NIP-44 methods are optional but preferred for relay storage (NIP-78)
- * because some NIP-46 bunkers don't grant nip04_decrypt permission.
+ * NIP-04 methods are required as a fallback for legacy data.
+ * NIP-44 methods are optional but preferred for both kind 10000 private
+ * mute lists (per NIP-51) and relay storage (NIP-78). NIP-44 is also
+ * better supported by NIP-46 bunkers which may deny nip04 permissions.
  */
 export interface Signer {
   getPublicKey(): Promise<string>;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -38,6 +38,9 @@ interface AppState {
   publicListsLoading: boolean;
   importedPackItems: Record<string, Set<string>>; // packId -> Set of imported item values
 
+  // Preferences
+  defaultMutePrivacy: boolean; // true = new mutes default to private
+
   // UI state
   activeTab:
     | "myList"
@@ -95,6 +98,7 @@ interface AppState {
   ) => void;
   setShowAuthModal: (show: boolean) => void;
   setHasCompletedOnboarding: (completed: boolean) => void;
+  setDefaultMutePrivacy: (isPrivate: boolean) => void;
 
   // Blacklist operations
   addToBlacklist: (pubkey: string) => void;
@@ -168,6 +172,7 @@ export const useStore = create<AppState>()(
       publicLists: [],
       publicListsLoading: false,
       importedPackItems: {},
+      defaultMutePrivacy: false,
       activeTab: "myList",
       showAuthModal: false,
       hasCompletedOnboarding: false,
@@ -271,11 +276,19 @@ export const useStore = create<AppState>()(
       setHasCompletedOnboarding: (completed) =>
         set({ hasCompletedOnboarding: completed }),
 
+      setDefaultMutePrivacy: (isPrivate) =>
+        set({ defaultMutePrivacy: isPrivate }),
+
       // Mute list CRUD operations
       addMutedItem: (item, category) =>
         set((state) => {
           const newList = { ...state.muteList };
-          newList[category] = [...newList[category], item as any];
+          // Apply default privacy if not explicitly set
+          const itemWithPrivacy =
+            item.private === undefined
+              ? { ...item, private: state.defaultMutePrivacy }
+              : item;
+          newList[category] = [...newList[category], itemWithPrivacy as any];
           return { muteList: newList, hasUnsavedChanges: true };
         }),
 
@@ -420,6 +433,7 @@ export const useStore = create<AppState>()(
         muteList: state.muteList,
         hasUnsavedChanges: state.hasUnsavedChanges,
         hasCompletedOnboarding: state.hasCompletedOnboarding,
+        defaultMutePrivacy: state.defaultMutePrivacy,
         // Persist user profile for faster display on reload
         userProfile: state.userProfile,
         // Persist NIP-46 session data for restoration (signer itself is not persisted)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mutable",
-  "version": "0.9.4",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mutable",
-      "version": "0.9.4",
+      "version": "1.1.1",
       "dependencies": {
         "@nostr-dev-kit/ndk": "^2.18.1",
         "@vercel/analytics": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutable",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- **NIP-44 encryption for private mutes** per NIP-51 spec, with NIP-04 fallback if signer lacks NIP-44
- **Auto-detect cipher** on decryption by checking for `?iv=` in ciphertext (NIP-51 spec method), removing the non-standard `["encryption"]` tag
- **Default mute privacy preference** — toggle in Settings and Privacy Controls to set whether new mutes default to public or private
- **Per-mute privacy override** — Public/Private toggle in the profile modal when muting a user
- **NsecSigner NIP-44 support** — adds `nip44Encrypt`/`nip44Decrypt` methods
- **Client compatibility notes** in UI text, encouraging users to ask client devs to follow NIP-51

## Client compatibility findings
| Client | Encrypts with | Decrypts with | Notes |
|--------|--------------|--------------|-------|
| Mutable (this PR) | NIP-44 (NIP-04 fallback) | Both via `?iv=` detection | Spec-conforming |
| Wisp | NIP-44 | NIP-44 only | Spec-conforming |
| Jumble | NIP-04 | NIP-04 only | Legacy |
| Primal | None | None | No private mute support |

## Test plan
- [ ] Mute a user with default public, verify public tag in event
- [ ] Toggle default to private, mute a user, verify encrypted content
- [ ] Override per-mute privacy in profile modal
- [ ] Verify existing NIP-04 encrypted mutes still decrypt correctly
- [ ] Verify NIP-44 encrypted mutes decrypt correctly
- [ ] Check Settings and Privacy Controls toggles stay in sync
- [ ] Test with NIP-07 and NIP-46 signers