### PR TITLE
v1.3.0: Bookmarks / pinned notes / interests relay backup

### DIFF
--- a/components/Backups.tsx
+++ b/components/Backups.tsx
@@ -1,11 +1,21 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { useStore } from "@/lib/store";
 import { useRelaySync } from "@/hooks/useRelaySync";
-import { backupService, Backup } from "@/lib/backupService";
-import { MuteBackupData, ProfileBackupData } from "@/lib/relayStorage";
+import {
+  backupService,
+  Backup,
+  BackupType,
+  RawListBackupPayload,
+  LIST_KIND_TO_TYPE,
+} from "@/lib/backupService";
+import {
+  MuteBackupData,
+  ProfileBackupData,
+  ListBackupResult,
+} from "@/lib/relayStorage";
 import { profileBackupService } from "@/lib/profileBackupService";
 import {
   getFollowListPubkeys,
@@ -14,6 +24,10 @@ import {
   publishProfile,
   fetchRawProfileContent,
 } from "@/lib/nostr";
+import {
+  fetchRawListEvent,
+  publishClonedRawListEvent,
+} from "@/lib/clonableService";
 import {
   Archive,
   Download,
@@ -34,16 +48,79 @@ import {
   ChevronUp,
   User,
   RotateCcw,
+  Bookmark,
+  Pin,
+  Hash,
 } from "lucide-react";
+
+type ListKind = 10001 | 10003 | 10015;
+const LIST_KINDS: ReadonlyArray<ListKind> = [10003, 10015, 10001];
+
+type RelayListBackup = NonNullable<ListBackupResult["backup"]>;
+
+interface BackupTypeMeta {
+  label: string;
+  badgeBg: string;
+  iconColor: string;
+  icon: typeof Archive;
+  tabActiveClass: string;
+  statCardIconBg: string;
+}
+
+const BACKUP_TYPE_META: Record<BackupType, BackupTypeMeta> = {
+  "mute-list": {
+    label: "Mute List Backup",
+    badgeBg: "bg-red-100 dark:bg-red-900/30",
+    iconColor: "text-red-600 dark:text-red-400",
+    icon: Shield,
+    tabActiveClass: "bg-red-600 text-white",
+    statCardIconBg: "bg-red-100 dark:bg-red-900/30",
+  },
+  "follow-list": {
+    label: "Follow List Backup",
+    badgeBg: "bg-blue-100 dark:bg-blue-900/30",
+    iconColor: "text-blue-600 dark:text-blue-400",
+    icon: Users,
+    tabActiveClass: "bg-blue-600 text-white",
+    statCardIconBg: "bg-blue-100 dark:bg-blue-900/30",
+  },
+  bookmarks: {
+    label: "Bookmarks Backup",
+    badgeBg: "bg-yellow-100 dark:bg-yellow-900/30",
+    iconColor: "text-yellow-600 dark:text-yellow-400",
+    icon: Bookmark,
+    tabActiveClass: "bg-yellow-600 text-white",
+    statCardIconBg: "bg-yellow-100 dark:bg-yellow-900/30",
+  },
+  "pinned-notes": {
+    label: "Pinned Notes Backup",
+    badgeBg: "bg-indigo-100 dark:bg-indigo-900/30",
+    iconColor: "text-indigo-600 dark:text-indigo-400",
+    icon: Pin,
+    tabActiveClass: "bg-indigo-600 text-white",
+    statCardIconBg: "bg-indigo-100 dark:bg-indigo-900/30",
+  },
+  interests: {
+    label: "Interests Backup",
+    badgeBg: "bg-teal-100 dark:bg-teal-900/30",
+    iconColor: "text-teal-600 dark:text-teal-400",
+    icon: Hash,
+    tabActiveClass: "bg-teal-600 text-white",
+    statCardIconBg: "bg-teal-100 dark:bg-teal-900/30",
+  },
+};
 
 export default function Backups() {
   const { session } = useAuth();
   const { muteList, setMuteList, signer } = useStore();
-  const { saveBackupToRelay, fetchBackupFromRelay } = useRelaySync();
+  const {
+    saveBackupToRelay,
+    fetchBackupFromRelay,
+    saveListBackupToRelay,
+    fetchListBackupFromRelay,
+  } = useRelaySync();
   const [backups, setBackups] = useState<Backup[]>([]);
-  const [selectedType, setSelectedType] = useState<
-    "all" | "mute-list" | "follow-list"
-  >("all");
+  const [selectedType, setSelectedType] = useState<"all" | BackupType>("all");
   const [isCreating, setIsCreating] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -58,6 +135,30 @@ export default function Backups() {
   const [foundOnRelays, setFoundOnRelays] = useState<string[]>([]);
   const [queriedRelays, setQueriedRelays] = useState<string[]>([]);
   const [relayBackupError, setRelayBackupError] = useState<string | null>(null);
+
+  // List (NIP-51) relay backup state — keyed by kind (10001 / 10003 / 10015)
+  const [listRelayBackups, setListRelayBackups] = useState<
+    Record<number, RelayListBackup | null>
+  >({});
+  const [listFoundOnRelays, setListFoundOnRelays] = useState<
+    Record<number, string[]>
+  >({});
+  const [listQueriedRelays, setListQueriedRelays] = useState<
+    Record<number, string[]>
+  >({});
+  const [listRelayErrors, setListRelayErrors] = useState<
+    Record<number, string | undefined>
+  >({});
+  const [listBackupLoading, setListBackupLoading] = useState<
+    Record<number, boolean>
+  >({});
+  const [listBackupSaving, setListBackupSaving] = useState<number | null>(null);
+  const [listBackupRestoring, setListBackupRestoring] = useState<
+    number | null
+  >(null);
+  const [showListRelayDetails, setShowListRelayDetails] = useState<
+    Record<number, boolean>
+  >({});
 
   // Profile backup state
   const [profileBackups, setProfileBackups] = useState<
@@ -77,7 +178,12 @@ export default function Backups() {
   useEffect(() => {
     if (session && signer) {
       loadRelayBackup(signer);
+      // Fetch list backups in parallel
+      for (const kind of LIST_KINDS) {
+        loadListRelayBackup(kind, signer);
+      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session, signer]);
 
   const loadBackups = () => {
@@ -110,6 +216,50 @@ export default function Backups() {
       setRelayBackupLoading(false);
     }
   };
+
+  const loadListRelayBackup = useCallback(
+    async (
+      kind: number,
+      signerOverride?: import("@/lib/signers").Signer,
+    ) => {
+      const activeSigner = signerOverride || useStore.getState().signer;
+      if (!activeSigner) {
+        console.warn(
+          `[Backups] No signer available for list relay backup fetch (kind ${kind})`,
+        );
+        return;
+      }
+
+      setListBackupLoading((prev) => ({ ...prev, [kind]: true }));
+      setListRelayErrors((prev) => ({ ...prev, [kind]: undefined }));
+      try {
+        const result = await fetchListBackupFromRelay(kind, activeSigner);
+        setListRelayBackups((prev) => ({
+          ...prev,
+          [kind]: result.backup || null,
+        }));
+        setListFoundOnRelays((prev) => ({
+          ...prev,
+          [kind]: result.foundOnRelays || [],
+        }));
+        setListQueriedRelays((prev) => ({
+          ...prev,
+          [kind]: result.queriedRelays || [],
+        }));
+        if (result.error) {
+          setListRelayErrors((prev) => ({ ...prev, [kind]: result.error }));
+        }
+      } catch (error) {
+        console.error(
+          `Failed to fetch list relay backup (kind ${kind}):`,
+          error,
+        );
+      } finally {
+        setListBackupLoading((prev) => ({ ...prev, [kind]: false }));
+      }
+    },
+    [fetchListBackupFromRelay],
+  );
 
   const loadProfileBackups = async () => {
     if (!session) return;
@@ -234,6 +384,25 @@ export default function Backups() {
           : "Mute list backup saved to relays";
         setSuccessMessage(message);
         setTimeout(() => setSuccessMessage(null), 5000);
+
+        // Mirror the list-backup pattern: write local-history entries so the
+        // Backups tab timeline stays consistent across all types.
+        const muteLocal = backupService.createMuteListBackup(
+          session.pubkey,
+          muteList,
+          "Saved from Backups tab (relay)",
+        );
+        backupService.saveBackup(muteLocal);
+        if (followList) {
+          const followLocal = backupService.createFollowListBackup(
+            session.pubkey,
+            followList,
+            "Saved from Backups tab (relay)",
+          );
+          backupService.saveBackup(followLocal);
+        }
+        loadBackups();
+
         // Refresh relay backup status
         await loadRelayBackup();
       } else {
@@ -371,6 +540,109 @@ export default function Backups() {
       );
     } finally {
       setIsCreating(false);
+    }
+  };
+
+  const handleSaveListToRelay = async (kind: ListKind) => {
+    if (!session) return;
+    const type = LIST_KIND_TO_TYPE[kind];
+    if (!type) return;
+
+    setListBackupSaving(kind);
+    setErrorMessage(null);
+    try {
+      const raw = await fetchRawListEvent(
+        session.pubkey,
+        kind,
+        session.relays,
+      );
+      if (!raw) {
+        setErrorMessage(
+          `Nothing to back up - no ${BACKUP_TYPE_META[type].label.replace(" Backup", "").toLowerCase()} event found on your relays`,
+        );
+        setTimeout(() => setErrorMessage(null), 5000);
+        return;
+      }
+
+      const payload: RawListBackupPayload = {
+        kind: raw.kind,
+        tags: raw.tags,
+        content: raw.content || "",
+      };
+
+      const result = await saveListBackupToRelay(
+        kind,
+        payload,
+        "Saved from Backups tab",
+      );
+      if (result.success) {
+        setSuccessMessage(
+          `${BACKUP_TYPE_META[type].label} saved to relays (${payload.tags.length} items${result.result ? `, ${result.result.savedChunks}/${result.result.totalChunks} chunks` : ""})`,
+        );
+        setTimeout(() => setSuccessMessage(null), 5000);
+
+        // Also create a local history entry so export is possible.
+        const localBackup = backupService.createListBackup(
+          session.pubkey,
+          type as "bookmarks" | "pinned-notes" | "interests",
+          payload,
+          "Saved from Backups tab (relay)",
+        );
+        if (backupService.saveBackup(localBackup)) {
+          loadBackups();
+        }
+
+        await loadListRelayBackup(kind);
+      } else {
+        setErrorMessage(result.error || "Failed to save list backup to relays");
+        setTimeout(() => setErrorMessage(null), 5000);
+      }
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to save list backup",
+      );
+      setTimeout(() => setErrorMessage(null), 5000);
+    } finally {
+      setListBackupSaving(null);
+    }
+  };
+
+  const handleRestoreListFromRelay = async (kind: ListKind) => {
+    if (!session) return;
+    const type = LIST_KIND_TO_TYPE[kind];
+    if (!type) return;
+    const backup = listRelayBackups[kind];
+    if (!backup) return;
+
+    const typeLabel = BACKUP_TYPE_META[type].label.replace(" Backup", "");
+    if (
+      !confirm(
+        `Restore your ${typeLabel.toLowerCase()} from relay backup? This will replace your current ${typeLabel.toLowerCase()} list on relays and publish it immediately.`,
+      )
+    ) {
+      return;
+    }
+
+    setListBackupRestoring(kind);
+    setErrorMessage(null);
+    try {
+      await publishClonedRawListEvent(
+        { kind: backup.kind, tags: backup.tags, content: backup.content },
+        session.relays,
+      );
+      setSuccessMessage(
+        `${typeLabel} restored and published (${backup.tags.length} items)`,
+      );
+      setTimeout(() => setSuccessMessage(null), 5000);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Failed to restore list backup from relays",
+      );
+      setTimeout(() => setErrorMessage(null), 5000);
+    } finally {
+      setListBackupRestoring(null);
     }
   };
 
@@ -530,6 +802,53 @@ export default function Backups() {
         setErrorMessage("Failed to restore and publish backup");
         setTimeout(() => setErrorMessage(null), 3000);
       }
+    } else if (
+      backup.type === "bookmarks" ||
+      backup.type === "pinned-notes" ||
+      backup.type === "interests"
+    ) {
+      const typeLabel = BACKUP_TYPE_META[backup.type].label.replace(
+        " Backup",
+        "",
+      );
+      if (
+        !confirm(
+          `Restore this ${typeLabel.toLowerCase()} backup? This will replace your current ${typeLabel.toLowerCase()} list and publish it immediately.`,
+        )
+      ) {
+        return;
+      }
+
+      try {
+        const payload = backupService.restoreListBackup(backup.id);
+        if (!payload) {
+          setErrorMessage("Failed to restore backup");
+          setTimeout(() => setErrorMessage(null), 3000);
+          return;
+        }
+        try {
+          await publishClonedRawListEvent(
+            {
+              kind: payload.kind,
+              tags: payload.tags,
+              content: payload.content,
+            },
+            session.relays,
+          );
+          setSuccessMessage(
+            `${typeLabel} restored and published (${payload.tags.length} items)`,
+          );
+          setTimeout(() => setSuccessMessage(null), 5000);
+        } catch (publishError) {
+          setErrorMessage(
+            "Backup restored but failed to publish. Please try publishing manually.",
+          );
+          setTimeout(() => setErrorMessage(null), 5000);
+        }
+      } catch (error) {
+        setErrorMessage("Failed to restore and publish backup");
+        setTimeout(() => setErrorMessage(null), 3000);
+      }
     }
   };
 
@@ -546,27 +865,34 @@ export default function Backups() {
         data.tags.length +
         data.threads.length
       );
-    } else {
+    }
+    if (backup.type === "follow-list") {
       return (backup.data as string[]).length;
     }
+    // bookmarks / pinned-notes / interests — RawListBackupPayload
+    const data = backup.data as RawListBackupPayload;
+    return Array.isArray(data?.tags) ? data.tags.length : 0;
   };
 
   const muteListBackups = backups.filter((b) => b.type === "mute-list");
   const followListBackups = backups.filter((b) => b.type === "follow-list");
+  const bookmarksBackups = backups.filter((b) => b.type === "bookmarks");
+  const pinnedNotesBackups = backups.filter((b) => b.type === "pinned-notes");
+  const interestsBackups = backups.filter((b) => b.type === "interests");
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
             Backups
           </h1>
           <p className="text-gray-600 dark:text-gray-400 mt-1">
-            Manage backups of your mute lists and follow lists
+            Manage backups of your mute list, follows, and bookmarks
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 flex-wrap">
           <button
             onClick={handleCreateMuteListBackup}
             disabled={isCreating}
@@ -583,6 +909,19 @@ export default function Backups() {
             <Users size={18} />
             <span className="hidden sm:inline">Backup Follows</span>
           </button>
+          <a
+            href="#list-relay-backup"
+            onClick={(e) => {
+              e.preventDefault();
+              document
+                .getElementById("list-relay-backup")
+                ?.scrollIntoView({ behavior: "smooth", block: "start" });
+            }}
+            className="flex items-center gap-2 px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+          >
+            <Bookmark size={18} />
+            <span className="hidden sm:inline">More Backups</span>
+          </a>
         </div>
       </div>
 
@@ -607,7 +946,7 @@ export default function Backups() {
       )}
 
       {/* Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
           <div className="flex items-center gap-3">
             <div className="p-3 bg-red-100 dark:bg-red-900/30 rounded-lg">
@@ -642,6 +981,25 @@ export default function Backups() {
 
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
           <div className="flex items-center gap-3">
+            <div className="p-3 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg">
+              <Bookmark
+                className="text-yellow-600 dark:text-yellow-400"
+                size={24}
+              />
+            </div>
+            <div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Bookmarks Backups
+              </p>
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {bookmarksBackups.length}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <div className="flex items-center gap-3">
             <div className="p-3 bg-gray-100 dark:bg-gray-700 rounded-lg">
               <Archive className="text-gray-600 dark:text-gray-400" size={24} />
             </div>
@@ -660,7 +1018,7 @@ export default function Backups() {
       {/* Actions Bar */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-          <div className="flex gap-2">
+          <div className="flex gap-2 flex-wrap">
             <button
               onClick={() => setSelectedType("all")}
               className={`px-4 py-2 rounded-lg font-medium transition-colors ${
@@ -671,26 +1029,27 @@ export default function Backups() {
             >
               All ({backups.length})
             </button>
-            <button
-              onClick={() => setSelectedType("mute-list")}
-              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                selectedType === "mute-list"
-                  ? "bg-red-600 text-white"
-                  : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600"
-              }`}
-            >
-              Mute Lists ({muteListBackups.length})
-            </button>
-            <button
-              onClick={() => setSelectedType("follow-list")}
-              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                selectedType === "follow-list"
-                  ? "bg-red-600 text-white"
-                  : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600"
-              }`}
-            >
-              Follow Lists ({followListBackups.length})
-            </button>
+            {(
+              [
+                ["mute-list", "Mute Lists", muteListBackups.length],
+                ["follow-list", "Follow Lists", followListBackups.length],
+                ["bookmarks", "Bookmarks", bookmarksBackups.length],
+                ["interests", "Interests", interestsBackups.length],
+                ["pinned-notes", "Pinned Notes", pinnedNotesBackups.length],
+              ] as Array<[BackupType, string, number]>
+            ).map(([type, label, count]) => (
+              <button
+                key={type}
+                onClick={() => setSelectedType(type)}
+                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                  selectedType === type
+                    ? BACKUP_TYPE_META[type].tabActiveClass
+                    : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600"
+                }`}
+              >
+                {label} ({count})
+              </button>
+            ))}
           </div>
 
           <div className="flex gap-2">
@@ -1013,7 +1372,215 @@ export default function Backups() {
         </div>
       </div>
 
+      {/* Bookmarks & Lists Relay Backup */}
+      <div
+        id="list-relay-backup"
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 scroll-mt-4"
+      >
+        <div className="flex items-start gap-4">
+          <div className="p-3 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg">
+            <Bookmark
+              className="text-yellow-600 dark:text-yellow-400"
+              size={24}
+            />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+              Bookmarks & Lists Relay Backup
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              Encrypted cross-device backups of your bookmarks, pinned notes,
+              and interests. Restore republishes the list verbatim — private
+              (encrypted) items survive without ever being decrypted here.
+            </p>
+
+            <div className="space-y-4">
+              {LIST_KINDS.map((kind) => {
+                const type = LIST_KIND_TO_TYPE[kind];
+                if (!type) return null;
+                const meta = BACKUP_TYPE_META[type];
+                const Icon = meta.icon;
+                const loading = !!listBackupLoading[kind];
+                const saving = listBackupSaving === kind;
+                const restoring = listBackupRestoring === kind;
+                const backup = listRelayBackups[kind] || null;
+                const err = listRelayErrors[kind];
+                const found = listFoundOnRelays[kind] || [];
+                const queried = listQueriedRelays[kind] || [];
+                const showDetails = !!showListRelayDetails[kind];
+
+                return (
+                  <div
+                    key={kind}
+                    className="border border-gray-200 dark:border-gray-700 rounded-lg p-4"
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className={`p-2 rounded-lg ${meta.badgeBg}`}>
+                        <Icon className={meta.iconColor} size={18} />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center justify-between gap-2 flex-wrap">
+                          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+                            {meta.label.replace(" Backup", "")}
+                          </h3>
+                          {loading ? (
+                            <span className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                              <RefreshCw size={12} className="animate-spin" />
+                              Checking…
+                            </span>
+                          ) : backup ? (
+                            <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                              <Cloud size={12} />
+                              Backed up {formatDate(backup.timestamp)}
+                            </span>
+                          ) : (
+                            <span className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                              <CloudOff size={12} />
+                              No relay backup
+                            </span>
+                          )}
+                        </div>
+
+                        {backup && (
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            {backup.tags.length} items
+                            {backup.content ? " • includes private items" : ""}
+                            {backup.fetchedChunks < backup.totalChunks
+                              ? ` • ${backup.fetchedChunks}/${backup.totalChunks} chunks reassembled`
+                              : ""}
+                          </p>
+                        )}
+
+                        {err && (
+                          <div className="mt-2 p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded">
+                            <div className="flex items-start gap-2">
+                              <AlertTriangle
+                                size={14}
+                                className="text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
+                              />
+                              <p className="text-xs text-amber-700 dark:text-amber-300">
+                                {err.includes("too large for remote signer") ||
+                                err.includes("plaintext size")
+                                  ? "Backup too large to decrypt with a remote signer (NIP-46). Log in with a browser extension (NIP-07) to decrypt."
+                                  : err}
+                              </p>
+                            </div>
+                          </div>
+                        )}
+
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          <button
+                            onClick={() => handleSaveListToRelay(kind)}
+                            disabled={saving || !session}
+                            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-purple-600 text-white rounded hover:bg-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {saving ? (
+                              <RefreshCw size={14} className="animate-spin" />
+                            ) : (
+                              <Cloud size={14} />
+                            )}
+                            Save to Relays
+                          </button>
+                          <button
+                            onClick={() => handleRestoreListFromRelay(kind)}
+                            disabled={restoring || !backup || !session}
+                            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {restoring ? (
+                              <RefreshCw size={14} className="animate-spin" />
+                            ) : (
+                              <Download size={14} />
+                            )}
+                            Restore from Relays
+                          </button>
+                          <button
+                            onClick={() => loadListRelayBackup(kind)}
+                            disabled={loading}
+                            className="flex items-center gap-2 px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+                            title="Refresh relay backup status"
+                          >
+                            <RefreshCw
+                              size={14}
+                              className={loading ? "animate-spin" : ""}
+                            />
+                          </button>
+                        </div>
+
+                        {queried.length > 0 && (
+                          <div className="mt-2">
+                            <button
+                              onClick={() =>
+                                setShowListRelayDetails((prev) => ({
+                                  ...prev,
+                                  [kind]: !prev[kind],
+                                }))
+                              }
+                              className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                            >
+                              {showDetails ? (
+                                <ChevronUp size={12} />
+                              ) : (
+                                <ChevronDown size={12} />
+                              )}
+                              <span>
+                                {showDetails ? "Hide" : "Show"} relays (
+                                {found.length}/{queried.length} have backup)
+                              </span>
+                            </button>
+                            {showDetails && (
+                              <div className="mt-2 p-2 bg-gray-50 dark:bg-gray-700/50 rounded">
+                                <ul className="text-xs space-y-1">
+                                  {queried.map((relay) => {
+                                    const has = found.includes(relay);
+                                    return (
+                                      <li
+                                        key={relay}
+                                        className={`truncate flex items-center gap-2 ${
+                                          has
+                                            ? "text-green-600 dark:text-green-400"
+                                            : "text-gray-400 dark:text-gray-500"
+                                        }`}
+                                      >
+                                        {has ? (
+                                          <CheckCircle
+                                            size={10}
+                                            className="flex-shrink-0"
+                                          />
+                                        ) : (
+                                          <CloudOff
+                                            size={10}
+                                            className="flex-shrink-0"
+                                          />
+                                        )}
+                                        {relay}
+                                      </li>
+                                    );
+                                  })}
+                                </ul>
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
       {/* Backups List */}
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Local Backup History
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 mb-3">
+          Snapshots saved in this browser. Download any entry as JSON for offline
+          safekeeping, or restore it to publish back to your relays.
+        </p>
+      </div>
       {filteredBackups.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-12 text-center">
           <Archive className="mx-auto text-gray-400 mb-4" size={48} />
@@ -1031,34 +1598,27 @@ export default function Backups() {
               key={backup.id}
               className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-3 sm:p-4 hover:shadow-md transition-shadow"
             >
+              {(() => {
+                const meta = BACKUP_TYPE_META[backup.type];
+                const RowIcon = meta?.icon || Archive;
+                return (
               <div className="flex items-start justify-between gap-2 sm:gap-4">
                 <div className="flex items-start gap-2 sm:gap-3 flex-1 min-w-0">
                   <div
-                    className={`p-2 rounded-lg flex-shrink-0 ${
-                      backup.type === "mute-list"
-                        ? "bg-red-100 dark:bg-red-900/30"
-                        : "bg-blue-100 dark:bg-blue-900/30"
-                    }`}
+                    className={`p-2 rounded-lg flex-shrink-0 ${meta?.badgeBg || "bg-gray-100 dark:bg-gray-700"}`}
                   >
-                    {backup.type === "mute-list" ? (
-                      <Shield
-                        className="text-red-600 dark:text-red-400"
-                        size={20}
-                      />
-                    ) : (
-                      <Users
-                        className="text-blue-600 dark:text-blue-400"
-                        size={20}
-                      />
-                    )}
+                    <RowIcon
+                      className={
+                        meta?.iconColor || "text-gray-600 dark:text-gray-400"
+                      }
+                      size={20}
+                    />
                   </div>
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1 flex-wrap">
                       <h3 className="font-semibold text-gray-900 dark:text-white">
-                        {backup.type === "mute-list"
-                          ? "Mute List Backup"
-                          : "Follow List Backup"}
+                        {meta?.label || backup.type}
                       </h3>
                       <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
                         ({getBackupItemCount(backup)} items)
@@ -1108,6 +1668,8 @@ export default function Backups() {
                   </button>
                 </div>
               </div>
+                );
+              })()}
             </div>
           ))}
         </div>

--- a/hooks/useRelaySync.ts
+++ b/hooks/useRelaySync.ts
@@ -12,8 +12,8 @@ import { blacklistService } from "@/lib/blacklistService";
 import { preferencesService } from "@/lib/preferencesService";
 import { importedPacksService } from "@/lib/importedPacksService";
 import { syncManager } from "@/lib/syncManager";
-import { backupService } from "@/lib/backupService";
-import { MuteBackupData } from "@/lib/relayStorage";
+import { backupService, RawListBackupPayload } from "@/lib/backupService";
+import { MuteBackupData, ListBackupResult } from "@/lib/relayStorage";
 import { MuteList } from "@/types";
 import { Signer } from "@/lib/signers";
 
@@ -232,6 +232,75 @@ export function useRelaySync() {
     );
   }, [session]);
 
+  /**
+   * Save a NIP-51 list backup (bookmarks / pinned notes / interests) to relays.
+   */
+  const saveListBackupToRelay = useCallback(
+    async (
+      kind: number,
+      rawEvent: RawListBackupPayload,
+      notes?: string,
+      signer?: Signer,
+    ) => {
+      if (!session) {
+        return { success: false, error: "No active session" };
+      }
+      return await backupService.saveListBackupToRelay(
+        kind,
+        rawEvent,
+        session.pubkey,
+        session.relays,
+        notes,
+        signer,
+      );
+    },
+    [session],
+  );
+
+  /**
+   * Fetch a NIP-51 list backup from relays.
+   */
+  const fetchListBackupFromRelay = useCallback(
+    async (
+      kind: number,
+      signer?: Signer,
+    ): Promise<{
+      success: boolean;
+      backup?: ListBackupResult["backup"];
+      foundOnRelays?: string[];
+      queriedRelays?: string[];
+      error?: string;
+    }> => {
+      if (!session) {
+        return { success: false, error: "No active session" };
+      }
+      return await backupService.fetchListBackupFromRelay(
+        kind,
+        session.pubkey,
+        session.relays,
+        signer,
+      );
+    },
+    [session],
+  );
+
+  /**
+   * Delete a NIP-51 list backup from relays.
+   */
+  const deleteListBackupFromRelay = useCallback(
+    async (kind: number) => {
+      if (!session) {
+        return { success: false, error: "No active session" };
+      }
+      return await backupService.deleteListBackupFromRelay(
+        kind,
+        session.pubkey,
+        session.relays,
+      );
+    },
+    [session],
+  );
+
   return {
     addProtection,
     removeProtection,
@@ -244,6 +313,9 @@ export function useRelaySync() {
     saveBackupToRelay,
     fetchBackupFromRelay,
     deleteMuteBackupFromRelay,
+    saveListBackupToRelay,
+    fetchListBackupFromRelay,
+    deleteListBackupFromRelay,
     isOnline: !!session,
   };
 }

--- a/lib/backupService.ts
+++ b/lib/backupService.ts
@@ -3,17 +3,72 @@ import {
   saveMuteBackupToRelay,
   fetchMuteBackupFromRelay,
   deleteMuteBackupFromRelay,
+  saveListBackupToRelay as saveListBackupToRelayImpl,
+  fetchListBackupFromRelay as fetchListBackupFromRelayImpl,
+  deleteListBackupFromRelay as deleteListBackupFromRelayImpl,
+  LIST_BACKUP_PREFIX,
   MuteBackupData,
+  ListBackupResult,
+  ListBackupSaveResult,
 } from "./relayStorage";
+
+export type BackupType =
+  | "mute-list"
+  | "follow-list"
+  | "bookmarks"
+  | "pinned-notes"
+  | "interests";
+
+export const LIST_BACKUP_TYPES: Readonly<BackupType[]> = [
+  "mute-list",
+  "follow-list",
+  "bookmarks",
+  "pinned-notes",
+  "interests",
+];
+
+// Map between NIP-51 list kind and BackupType for the three list-backup kinds.
+export const LIST_KIND_TO_TYPE: Record<number, BackupType> = {
+  10001: "pinned-notes",
+  10003: "bookmarks",
+  10015: "interests",
+};
+export const LIST_TYPE_TO_KIND: Partial<Record<BackupType, number>> = {
+  "pinned-notes": 10001,
+  bookmarks: 10003,
+  interests: 10015,
+};
+
+/**
+ * Raw NIP-51 list event payload stored in a list-type Backup. Kept opaque:
+ * `content` may be NIP-04/NIP-44 ciphertext (private list items) and is
+ * preserved verbatim so restore round-trips without ever decrypting.
+ */
+export interface RawListBackupPayload {
+  kind: number;
+  tags: string[][];
+  content: string;
+}
 
 export interface Backup {
   id: string;
-  type: "mute-list" | "follow-list";
+  type: BackupType;
   pubkey: string;
-  data: MuteList | string[]; // MuteList for mute-list, string[] of pubkeys for follow-list
+  // mute-list → MuteList; follow-list → string[]; list types → RawListBackupPayload
+  data: MuteList | string[] | RawListBackupPayload;
   createdAt: number;
   notes?: string;
   eventId?: string; // The Nostr event ID this backup was created from
+}
+
+function isRawListBackupPayload(value: unknown): value is RawListBackupPayload {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<RawListBackupPayload>;
+  return (
+    typeof v.kind === "number" &&
+    Array.isArray(v.tags) &&
+    typeof v.content === "string"
+  );
 }
 
 class BackupService {
@@ -72,12 +127,13 @@ class BackupService {
   /**
    * Get backups filtered by type
    */
-  getBackupsByType(type: "mute-list" | "follow-list"): Backup[] {
+  getBackupsByType(type: BackupType): Backup[] {
     return this.getAllBackups().filter((backup) => backup.type === type);
   }
 
   /**
-   * Save a backup
+   * Save a backup. Caps each backup type at MAX_BACKUPS independently so
+   * adding a new type never evicts backups of existing types.
    */
   saveBackup(backup: Backup): boolean {
     try {
@@ -86,19 +142,26 @@ class BackupService {
       // Add new backup
       backups.unshift(backup); // Add to beginning
 
-      // Limit backups per type
-      const muteBackups = backups
-        .filter((b) => b.type === "mute-list")
-        .slice(0, this.MAX_BACKUPS);
-      const followBackups = backups
-        .filter((b) => b.type === "follow-list")
-        .slice(0, this.MAX_BACKUPS);
+      // Cap each known type at MAX_BACKUPS independently. Anything with an
+      // unknown type is preserved as-is so forward-compat backups are not lost.
+      const byType: Record<string, Backup[]> = {};
+      const unknownTypeBackups: Backup[] = [];
+      for (const b of backups) {
+        if (LIST_BACKUP_TYPES.includes(b.type)) {
+          (byType[b.type] = byType[b.type] || []).push(b);
+        } else {
+          unknownTypeBackups.push(b);
+        }
+      }
 
-      const limitedBackups = [...muteBackups, ...followBackups].sort(
-        (a, b) => b.createdAt - a.createdAt,
-      );
+      const limited: Backup[] = [];
+      for (const type of LIST_BACKUP_TYPES) {
+        limited.push(...(byType[type] || []).slice(0, this.MAX_BACKUPS));
+      }
+      limited.push(...unknownTypeBackups);
+      limited.sort((a, b) => b.createdAt - a.createdAt);
 
-      localStorage.setItem(this.BACKUP_KEY, JSON.stringify(limitedBackups));
+      localStorage.setItem(this.BACKUP_KEY, JSON.stringify(limited));
       return true;
     } catch (error) {
       console.error("Failed to save backup:", error);
@@ -147,6 +210,29 @@ class BackupService {
   }
 
   /**
+   * Create a NIP-51 list-type backup (bookmarks / pinned notes / interests).
+   * `data` preserves the raw event tags + (possibly encrypted) content so
+   * restore can republish the event verbatim.
+   */
+  createListBackup(
+    pubkey: string,
+    type: "bookmarks" | "pinned-notes" | "interests",
+    payload: RawListBackupPayload,
+    notes?: string,
+    eventId?: string,
+  ): Backup {
+    return {
+      id: this.generateBackupId(),
+      type,
+      pubkey,
+      data: payload,
+      createdAt: Date.now(),
+      notes,
+      eventId,
+    };
+  }
+
+  /**
    * Export a backup to JSON file
    */
   exportBackupToFile(backup: Backup): void {
@@ -187,7 +273,7 @@ class BackupService {
       }
 
       // Validate type
-      if (backup.type !== "mute-list" && backup.type !== "follow-list") {
+      if (!LIST_BACKUP_TYPES.includes(backup.type)) {
         return { success: false, error: "Invalid backup type" };
       }
 
@@ -205,6 +291,24 @@ class BackupService {
       } else if (backup.type === "follow-list") {
         if (!Array.isArray(backup.data)) {
           return { success: false, error: "Invalid follow list backup format" };
+        }
+      } else if (
+        backup.type === "bookmarks" ||
+        backup.type === "pinned-notes" ||
+        backup.type === "interests"
+      ) {
+        if (!isRawListBackupPayload(backup.data)) {
+          return {
+            success: false,
+            error: `Invalid ${backup.type} backup format`,
+          };
+        }
+        const expectedKind = LIST_TYPE_TO_KIND[backup.type];
+        if (expectedKind && backup.data.kind !== expectedKind) {
+          return {
+            success: false,
+            error: `Backup kind ${backup.data.kind} does not match type ${backup.type}`,
+          };
         }
       }
 
@@ -266,7 +370,7 @@ class BackupService {
   /**
    * Get the most recent backup of a specific type
    */
-  getMostRecentBackup(type: "mute-list" | "follow-list"): Backup | null {
+  getMostRecentBackup(type: BackupType): Backup | null {
     const backups = this.getBackupsByType(type);
     if (backups.length === 0) return null;
     return backups[0]; // Already sorted by createdAt descending
@@ -277,7 +381,7 @@ class BackupService {
    * Returns true if last backup was more than X days ago
    */
   shouldRemindBackup(
-    type: "mute-list" | "follow-list",
+    type: BackupType,
     daysSinceLastBackup: number = 7,
   ): boolean {
     const lastBackup = this.getMostRecentBackup(type);
@@ -310,6 +414,24 @@ class BackupService {
       return null;
     }
     return backup.data as string[];
+  }
+
+  /**
+   * Restore a list-type backup (bookmarks / pinned notes / interests).
+   * Returns the raw NIP-51 payload if successful, null otherwise.
+   */
+  restoreListBackup(backupId: string): RawListBackupPayload | null {
+    const backup = this.getBackupById(backupId);
+    if (!backup) return null;
+    if (
+      backup.type !== "bookmarks" &&
+      backup.type !== "pinned-notes" &&
+      backup.type !== "interests"
+    ) {
+      return null;
+    }
+    if (!isRawListBackupPayload(backup.data)) return null;
+    return backup.data;
   }
 
   // =============================================================================
@@ -409,6 +531,128 @@ class BackupService {
           error instanceof Error
             ? error.message
             : "Failed to delete backup from relay",
+      };
+    }
+  }
+
+  // =============================================================================
+  // List (NIP-51) Backup Relay Functions — bookmarks / pinned notes / interests
+  // =============================================================================
+
+  /**
+   * Save a NIP-51 list backup to relays (encrypted, chunked).
+   */
+  async saveListBackupToRelay(
+    kind: number,
+    rawEvent: RawListBackupPayload,
+    userPubkey: string,
+    relays: string[],
+    notes?: string,
+    signer?: import("./signers").Signer,
+  ): Promise<{ success: boolean; result?: ListBackupSaveResult; error?: string }> {
+    if (!LIST_BACKUP_PREFIX[kind]) {
+      return { success: false, error: `Unsupported list backup kind: ${kind}` };
+    }
+    try {
+      const result = await saveListBackupToRelayImpl(
+        kind,
+        rawEvent,
+        userPubkey,
+        relays,
+        notes,
+        signer,
+      );
+      if (result.savedChunks === 0) {
+        return {
+          success: false,
+          result,
+          error: "Failed to save any chunks to relays",
+        };
+      }
+      return { success: true, result };
+    } catch (error) {
+      console.error("Failed to save list backup to relays:", error);
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to save list backup to relays",
+      };
+    }
+  }
+
+  /**
+   * Fetch a NIP-51 list backup from relays (chunks reassembled).
+   */
+  async fetchListBackupFromRelay(
+    kind: number,
+    userPubkey: string,
+    relays: string[],
+    signer?: import("./signers").Signer,
+  ): Promise<{
+    success: boolean;
+    backup?: ListBackupResult["backup"];
+    foundOnRelays?: string[];
+    queriedRelays?: string[];
+    error?: string;
+  }> {
+    if (!LIST_BACKUP_PREFIX[kind]) {
+      return { success: false, error: `Unsupported list backup kind: ${kind}` };
+    }
+    try {
+      const result = await fetchListBackupFromRelayImpl(
+        kind,
+        userPubkey,
+        relays,
+        5000,
+        signer,
+      );
+      return {
+        success: true,
+        backup: result.backup || undefined,
+        foundOnRelays: result.foundOnRelays,
+        queriedRelays: result.queriedRelays,
+        error: result.decryptError,
+      };
+    } catch (error) {
+      console.error("Failed to fetch list backup from relays:", error);
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch list backup from relays",
+      };
+    }
+  }
+
+  /**
+   * Delete a NIP-51 list backup from relays (all chunks).
+   */
+  async deleteListBackupFromRelay(
+    kind: number,
+    userPubkey: string,
+    relays: string[],
+  ): Promise<{ success: boolean; deletedChunks?: number; error?: string }> {
+    if (!LIST_BACKUP_PREFIX[kind]) {
+      return { success: false, error: `Unsupported list backup kind: ${kind}` };
+    }
+    try {
+      const { deletedChunks } = await deleteListBackupFromRelayImpl(
+        kind,
+        userPubkey,
+        relays,
+      );
+      return { success: true, deletedChunks };
+    } catch (error) {
+      console.error("Failed to delete list backup from relay:", error);
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to delete list backup from relay",
       };
     }
   }

--- a/lib/clonableService.ts
+++ b/lib/clonableService.ts
@@ -50,7 +50,7 @@ export interface CloneableData {
 /**
  * Fetch a raw list event by kind for a given pubkey.
  */
-async function fetchRawListEvent(
+export async function fetchRawListEvent(
   pubkey: string,
   kind: number,
   relays: string[],
@@ -70,7 +70,7 @@ async function fetchRawListEvent(
 /**
  * Publish a raw list event, optionally using a destination signer.
  */
-async function publishClonedRawListEvent(
+export async function publishClonedRawListEvent(
   event: RawListEvent,
   relays: string[],
   destinationSigner?: NsecSigner,

--- a/lib/relayStorage.ts
+++ b/lib/relayStorage.ts
@@ -32,10 +32,18 @@ export const D_TAGS = {
   PROFILE_BACKUP_0: "mutable:profile-backup:0",
   PROFILE_BACKUP_1: "mutable:profile-backup:1",
   PROFILE_BACKUP_2: "mutable:profile-backup:2",
+  BOOKMARKS_BACKUP: "mutable:bookmarks-backup",
+  PINNED_NOTES_BACKUP: "mutable:pinned-notes-backup",
+  INTERESTS_BACKUP: "mutable:interests-backup",
 } as const;
 
-// DTagType includes static tags plus dynamic follow backup chunk tags
-export type DTagType = (typeof D_TAGS)[keyof typeof D_TAGS] | `mutable:follow-backup:${number}`;
+// DTagType includes static tags plus dynamic follow/list backup chunk tags
+export type DTagType =
+  | (typeof D_TAGS)[keyof typeof D_TAGS]
+  | `mutable:follow-backup:${number}`
+  | `mutable:bookmarks-backup:${number}`
+  | `mutable:pinned-notes-backup:${number}`
+  | `mutable:interests-backup:${number}`;
 
 // Max follows per chunk to stay within NIP-46 transport limits (65KB)
 // 500 pubkeys × ~66 bytes = ~33KB raw → ~20KB compressed → well under 65KB
@@ -95,6 +103,23 @@ export interface ProfileBackupData {
   profile: Record<string, unknown>; // full kind:0 content JSON
 }
 
+/**
+ * Backup payload for generic NIP-51 list events (bookmarks, pinned notes, interests).
+ * The list event's tags are split across chunks; `content` (which may be
+ * NIP-04/NIP-44 ciphertext holding private list items) is stored verbatim on
+ * chunkIndex 0 only and treated as opaque.
+ */
+export interface ListBackupData {
+  version: number;
+  timestamp: number;
+  kind: number; // 10001 | 10003 | 10015
+  tags: string[][];
+  content?: string;
+  totalChunks: number;
+  chunkIndex: number;
+  notes?: string;
+}
+
 // Union type for all data types
 export type StorageData =
   | ProtectedUsersData
@@ -102,7 +127,8 @@ export type StorageData =
   | PreferencesData
   | ImportedPacksData
   | MuteBackupData
-  | ProfileBackupData;
+  | ProfileBackupData
+  | ListBackupData;
 
 // Prefix marker for compressed data (added before NIP-04 encryption)
 const COMPRESSED_PREFIX = "gz:";
@@ -953,4 +979,329 @@ export async function deleteMuteBackupFromRelay(
 ): Promise<Event> {
   console.log(`[RelayStorage] Deleting mute backup from relay...`);
   return deleteAppData(D_TAGS.MUTE_BACKUP, userPubkey, relays);
+}
+
+// =============================================================================
+// Generic NIP-51 list backup (bookmarks, pinned notes, interests)
+// =============================================================================
+
+// d-tag prefix per supported NIP-51 list kind. Actual d-tags include :${chunkIndex}.
+export const LIST_BACKUP_PREFIX: Record<number, string> = {
+  10001: "mutable:pinned-notes-backup",
+  10003: "mutable:bookmarks-backup",
+  10015: "mutable:interests-backup",
+};
+
+// Chunk size for splitting tags across NIP-78 events. 500 × ~80 bytes ≈ 40KB
+// raw → ~20KB compressed, well under the NIP-46 65KB transport limit.
+export const LIST_TAG_CHUNK_SIZE = 500;
+
+// Hard cap on chunks we will publish or fetch. Covers very large lists
+// (up to 20,000 items) while preventing runaway fetch loops.
+export const MAX_LIST_CHUNKS = 40;
+
+function listBackupDTag(
+  kind: number,
+  chunkIndex: number,
+): DTagType {
+  const prefix = LIST_BACKUP_PREFIX[kind];
+  if (!prefix) {
+    throw new Error(`Unsupported list backup kind: ${kind}`);
+  }
+  return `${prefix}:${chunkIndex}` as DTagType;
+}
+
+export interface ListBackupSaveResult {
+  savedChunks: number;
+  totalChunks: number;
+}
+
+/**
+ * Save a NIP-51 list event as a chunked, encrypted backup on relays.
+ * The event's tags are split into LIST_TAG_CHUNK_SIZE slices; the (possibly
+ * encrypted) `content` is stored only on chunk 0.
+ */
+export async function saveListBackupToRelay(
+  kind: number,
+  rawEvent: { tags: string[][]; content: string },
+  userPubkey: string,
+  relays: string[],
+  notes?: string,
+  explicitSigner?: import("./signers").Signer,
+): Promise<ListBackupSaveResult> {
+  if (!LIST_BACKUP_PREFIX[kind]) {
+    throw new Error(`Unsupported list backup kind: ${kind}`);
+  }
+
+  const timestamp = Date.now();
+  const tags = rawEvent.tags || [];
+  const totalChunks = Math.max(1, Math.ceil(tags.length / LIST_TAG_CHUNK_SIZE));
+
+  if (totalChunks > MAX_LIST_CHUNKS) {
+    throw new Error(
+      `List backup for kind ${kind} has ${totalChunks} chunks which exceeds the ${MAX_LIST_CHUNKS} chunk limit.`,
+    );
+  }
+
+  console.log(
+    `[RelayStorage] Saving list backup (kind ${kind}, ${tags.length} tags) in ${totalChunks} chunk(s)...`,
+  );
+
+  let savedChunks = 0;
+  for (let i = 0; i < totalChunks; i++) {
+    const slice = tags.slice(
+      i * LIST_TAG_CHUNK_SIZE,
+      (i + 1) * LIST_TAG_CHUNK_SIZE,
+    );
+    const payload: ListBackupData = {
+      version: 1,
+      timestamp,
+      kind,
+      tags: slice,
+      totalChunks,
+      chunkIndex: i,
+      notes,
+      // Content lives on chunk 0 only — it's one opaque ciphertext blob.
+      ...(i === 0 ? { content: rawEvent.content || "" } : {}),
+    };
+
+    try {
+      await publishAppData(
+        listBackupDTag(kind, i),
+        payload,
+        userPubkey,
+        relays,
+        true,
+        explicitSigner,
+      );
+      savedChunks++;
+    } catch (error) {
+      console.warn(
+        `[RelayStorage] Failed to save list backup chunk ${i}/${totalChunks} for kind ${kind}:`,
+        error,
+      );
+    }
+  }
+
+  console.log(
+    `[RelayStorage] List backup for kind ${kind}: saved ${savedChunks}/${totalChunks} chunks`,
+  );
+
+  return { savedChunks, totalChunks };
+}
+
+export interface ListBackupResult {
+  backup: {
+    kind: number;
+    tags: string[][];
+    content: string;
+    timestamp: number;
+    notes?: string;
+    totalChunks: number;
+    fetchedChunks: number;
+  } | null;
+  foundOnRelays: string[];
+  queriedRelays: string[];
+  decryptError?: string;
+}
+
+/**
+ * Fetch a chunked list backup from relays and reassemble it.
+ * Chunk 0 is authoritative for timestamp / notes / content; missing chunk 0
+ * is treated as a hard failure (no backup found). Missing later chunks are
+ * reported via `fetchedChunks` so the UI can warn the user.
+ */
+export async function fetchListBackupFromRelay(
+  kind: number,
+  userPubkey: string,
+  relays: string[],
+  timeoutMs: number = 5000,
+  explicitSigner?: import("./signers").Signer,
+): Promise<ListBackupResult> {
+  if (!LIST_BACKUP_PREFIX[kind]) {
+    throw new Error(`Unsupported list backup kind: ${kind}`);
+  }
+
+  const pool = getPool();
+  const expandedRelays = getExpandedRelayList(relays);
+  const chunk0DTag = listBackupDTag(kind, 0);
+
+  console.log(
+    `[RelayStorage] Fetching list backup (kind ${kind}) from ${expandedRelays.length} relays...`,
+  );
+
+  // Step 1: find which relays hold chunk 0 and grab the latest chunk-0 event.
+  const foundOnRelays: string[] = [];
+  let latestChunk0: Event | null = null;
+
+  const relayPromises = expandedRelays.map(async (relayUrl) => {
+    return new Promise<{ relay: string; event: Event | null }>((resolve) => {
+      const relayTimeoutId = setTimeout(() => {
+        resolve({ relay: relayUrl, event: null });
+      }, timeoutMs);
+
+      try {
+        const sub = pool.subscribeMany(
+          [relayUrl],
+          {
+            kinds: [APP_DATA_KIND],
+            authors: [userPubkey],
+            "#d": [chunk0DTag],
+          },
+          {
+            onevent(event: Event) {
+              clearTimeout(relayTimeoutId);
+              sub.close();
+              resolve({ relay: relayUrl, event });
+            },
+            oneose() {
+              clearTimeout(relayTimeoutId);
+              sub.close();
+              resolve({ relay: relayUrl, event: null });
+            },
+          },
+        );
+      } catch (error) {
+        clearTimeout(relayTimeoutId);
+        console.warn(`[RelayStorage] Error querying ${relayUrl}:`, error);
+        resolve({ relay: relayUrl, event: null });
+      }
+    });
+  });
+
+  const results = await Promise.all(relayPromises);
+  for (const result of results) {
+    if (result.event) {
+      foundOnRelays.push(result.relay);
+      if (!latestChunk0 || result.event.created_at > latestChunk0.created_at) {
+        latestChunk0 = result.event;
+      }
+    }
+  }
+
+  if (!latestChunk0) {
+    console.log(`[RelayStorage] No list backup found for kind ${kind}`);
+    return {
+      backup: null,
+      foundOnRelays: [],
+      queriedRelays: expandedRelays,
+    };
+  }
+
+  // Step 2: decrypt chunk 0.
+  let chunk0: ListBackupData;
+  try {
+    const data = await processEvent(latestChunk0, explicitSigner);
+    if (!data) {
+      return { backup: null, foundOnRelays, queriedRelays: expandedRelays };
+    }
+    chunk0 = data as ListBackupData;
+    if (
+      typeof chunk0.timestamp !== "number" ||
+      typeof chunk0.totalChunks !== "number" ||
+      !Array.isArray(chunk0.tags)
+    ) {
+      console.error(`[RelayStorage] Invalid list backup chunk 0 structure`);
+      return { backup: null, foundOnRelays, queriedRelays: expandedRelays };
+    }
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[RelayStorage] Error processing list backup chunk 0:`,
+      errorMsg,
+    );
+    return {
+      backup: null,
+      foundOnRelays,
+      queriedRelays: expandedRelays,
+      decryptError: errorMsg,
+    };
+  }
+
+  const totalChunks = Math.min(chunk0.totalChunks || 1, MAX_LIST_CHUNKS);
+  const allTags: string[][] = [...chunk0.tags];
+  let fetchedChunks = 1;
+
+  // Step 3: fetch remaining chunks in parallel.
+  if (totalChunks > 1) {
+    const chunkPromises: Promise<StorageData | null>[] = [];
+    for (let i = 1; i < totalChunks; i++) {
+      chunkPromises.push(
+        fetchAppData(
+          listBackupDTag(kind, i),
+          userPubkey,
+          relays,
+          timeoutMs,
+          explicitSigner,
+        ),
+      );
+    }
+    const chunkResults = await Promise.allSettled(chunkPromises);
+    for (const result of chunkResults) {
+      if (result.status === "fulfilled" && result.value) {
+        const chunk = result.value as ListBackupData;
+        if (Array.isArray(chunk.tags)) {
+          allTags.push(...chunk.tags);
+          fetchedChunks++;
+        }
+      }
+    }
+    console.log(
+      `[RelayStorage] List backup (kind ${kind}): fetched ${fetchedChunks}/${totalChunks} chunks`,
+    );
+  }
+
+  return {
+    backup: {
+      kind: chunk0.kind || kind,
+      tags: allTags,
+      content: chunk0.content || "",
+      timestamp: chunk0.timestamp,
+      notes: chunk0.notes,
+      totalChunks,
+      fetchedChunks,
+    },
+    foundOnRelays,
+    queriedRelays: expandedRelays,
+  };
+}
+
+/**
+ * Delete a chunked list backup from relays by publishing kind-5 deletions for
+ * each chunk's d-tag.
+ */
+export async function deleteListBackupFromRelay(
+  kind: number,
+  userPubkey: string,
+  relays: string[],
+): Promise<{ deletedChunks: number }> {
+  if (!LIST_BACKUP_PREFIX[kind]) {
+    throw new Error(`Unsupported list backup kind: ${kind}`);
+  }
+
+  // Determine how many chunks exist so we don't publish spurious deletions.
+  const existing = await fetchListBackupFromRelay(kind, userPubkey, relays);
+  const totalChunks = existing.backup?.totalChunks || 0;
+  if (totalChunks === 0) {
+    return { deletedChunks: 0 };
+  }
+
+  let deletedChunks = 0;
+  for (let i = 0; i < totalChunks; i++) {
+    try {
+      await deleteAppData(listBackupDTag(kind, i), userPubkey, relays);
+      deletedChunks++;
+    } catch (error) {
+      // deleteAppData throws if the event is gone — not a problem.
+      console.warn(
+        `[RelayStorage] Could not delete list backup chunk ${i} for kind ${kind}:`,
+        error,
+      );
+    }
+  }
+
+  console.log(
+    `[RelayStorage] Deleted ${deletedChunks}/${totalChunks} chunks for kind ${kind}`,
+  );
+  return { deletedChunks };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mutable",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mutable",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@nostr-dev-kit/ndk": "^2.18.1",
         "@vercel/analytics": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutable",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/list-backup-chunking.test.ts
+++ b/tests/list-backup-chunking.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  generateSecretKey,
+  getPublicKey,
+  finalizeEvent,
+  Event,
+  EventTemplate,
+  Filter,
+} from "nostr-tools";
+import { NsecSigner } from "@/lib/signers/NsecSigner";
+
+/**
+ * Chunking test for list backup.
+ *
+ * Stubs out `@/lib/nostr` so `publishAppData` can run its real
+ * compress + encrypt + sign pipeline without touching the network.
+ * Captures the signed events so the test can assert:
+ *   - correct number of chunks
+ *   - correct d-tag per chunk
+ *   - chunkIndex / totalChunks / kind inside each payload
+ *   - content is present only on chunk 0
+ *   - tags reassemble in order via fetchListBackupFromRelay
+ */
+
+const secretKey = generateSecretKey();
+const userPubkey = getPublicKey(secretKey);
+const testSigner = new NsecSigner(secretKey);
+
+// Storage shared across mock boundaries
+const eventsByDTag = new Map<string, Event>();
+
+vi.mock("@/lib/store", () => ({
+  useStore: {
+    getState: () => ({ session: null }),
+  },
+}));
+
+vi.mock("@/lib/nostr", () => {
+  type Handlers = {
+    onevent?: (e: Event) => void;
+    oneose?: () => void;
+  };
+  return {
+    getPool: () => ({
+      publish: (relays: string[], event: Event) => {
+        const dTag = event.tags.find((t) => t[0] === "d")?.[1];
+        if (dTag) eventsByDTag.set(dTag, event);
+        return relays.map(() => Promise.resolve());
+      },
+      subscribeMany: (_relays: string[], filter: Filter, handlers: Handlers) => {
+        const dTags = (filter["#d"] as string[] | undefined) || [];
+        const authors = (filter.authors as string[] | undefined) || [];
+        queueMicrotask(() => {
+          for (const dTag of dTags) {
+            const event = eventsByDTag.get(dTag);
+            if (event && (authors.length === 0 || authors.includes(event.pubkey))) {
+              handlers.onevent?.(event);
+            }
+          }
+          handlers.oneose?.();
+        });
+        return { close: () => {} };
+      },
+    }),
+    getExpandedRelayList: (relays: string[]) => relays,
+    getSigner: () => testSigner,
+    signEvent: async (template: EventTemplate) =>
+      finalizeEvent(template, secretKey),
+    DEFAULT_RELAYS: ["wss://relay.test"],
+  };
+});
+
+// Import under test after mocks are registered
+import {
+  saveListBackupToRelay,
+  fetchListBackupFromRelay,
+  APP_DATA_KIND,
+  LIST_TAG_CHUNK_SIZE,
+} from "@/lib/relayStorage";
+
+const RELAYS = ["wss://relay.test"];
+
+beforeEach(() => {
+  eventsByDTag.clear();
+});
+
+describe("list backup chunking (kind 10003 bookmarks)", () => {
+  it(
+    "splits 1300 tags across 3 chunks with content only on chunk 0",
+    async () => {
+      // 1300 tags = ceil(1300 / 500) = 3 chunks
+      const totalTagCount = 1300;
+      const tags: string[][] = [];
+      for (let i = 0; i < totalTagCount; i++) {
+        tags.push(["e", `tag-${i}`.padEnd(64, "0")]);
+      }
+      // Ciphertext-like blob (opaque; chunk 0 only)
+      const content = "ciphertext-blob-" + "x".repeat(2048);
+
+      const result = await saveListBackupToRelay(
+        10003,
+        { tags, content },
+        userPubkey,
+        RELAYS,
+        "unit test",
+        testSigner,
+      );
+
+      expect(result.totalChunks).toBe(3);
+      expect(result.savedChunks).toBe(3);
+
+      // Verify event metadata (unencrypted) and d-tags.
+      const dTags = Array.from(eventsByDTag.keys()).sort();
+      expect(dTags).toEqual([
+        "mutable:bookmarks-backup:0",
+        "mutable:bookmarks-backup:1",
+        "mutable:bookmarks-backup:2",
+      ]);
+      for (const event of eventsByDTag.values()) {
+        expect(event.kind).toBe(APP_DATA_KIND);
+        expect(event.pubkey).toBe(userPubkey);
+        expect(event.tags.find((t) => t[0] === "encrypted")?.[1]).toBe("true");
+        expect(event.tags.find((t) => t[0] === "enc")?.[1]).toBe("nip44");
+      }
+
+      // Reassemble via fetch — exercises decryption + decompression.
+      const fetched = await fetchListBackupFromRelay(
+        10003,
+        userPubkey,
+        RELAYS,
+        1000,
+        testSigner,
+      );
+      expect(fetched.backup).not.toBeNull();
+      expect(fetched.backup!.totalChunks).toBe(3);
+      expect(fetched.backup!.fetchedChunks).toBe(3);
+      expect(fetched.backup!.kind).toBe(10003);
+      expect(fetched.backup!.content).toBe(content);
+      expect(fetched.backup!.tags).toEqual(tags);
+    },
+    30000,
+  );
+
+  it(
+    "preserves tag order across chunks (first/last items of each slice)",
+    async () => {
+      const tags: string[][] = [];
+      for (let i = 0; i < LIST_TAG_CHUNK_SIZE * 2 + 10; i++) {
+        tags.push(["p", String(i)]);
+      }
+
+      await saveListBackupToRelay(
+        10003,
+        { tags, content: "" },
+        userPubkey,
+        RELAYS,
+        undefined,
+        testSigner,
+      );
+
+      const fetched = await fetchListBackupFromRelay(
+        10003,
+        userPubkey,
+        RELAYS,
+        1000,
+        testSigner,
+      );
+      expect(fetched.backup).not.toBeNull();
+      expect(fetched.backup!.tags).toHaveLength(tags.length);
+      // Spot-check ordering at chunk boundaries
+      expect(fetched.backup!.tags[0]).toEqual(["p", "0"]);
+      expect(fetched.backup!.tags[LIST_TAG_CHUNK_SIZE - 1]).toEqual([
+        "p",
+        String(LIST_TAG_CHUNK_SIZE - 1),
+      ]);
+      expect(fetched.backup!.tags[LIST_TAG_CHUNK_SIZE]).toEqual([
+        "p",
+        String(LIST_TAG_CHUNK_SIZE),
+      ]);
+      expect(fetched.backup!.tags[tags.length - 1]).toEqual([
+        "p",
+        String(tags.length - 1),
+      ]);
+    },
+    30000,
+  );
+
+  it(
+    "single-chunk backup uses totalChunks=1",
+    async () => {
+      const tags = Array.from({ length: 5 }, (_, i) => ["t", `t${i}`]);
+      const result = await saveListBackupToRelay(
+        10003,
+        { tags, content: "small-content" },
+        userPubkey,
+        RELAYS,
+        undefined,
+        testSigner,
+      );
+      expect(result.totalChunks).toBe(1);
+      expect(eventsByDTag.size).toBe(1);
+      expect(eventsByDTag.has("mutable:bookmarks-backup:0")).toBe(true);
+    },
+    15000,
+  );
+
+  it(
+    "empty tag list still produces a single chunk with the content blob",
+    async () => {
+      const result = await saveListBackupToRelay(
+        10003,
+        { tags: [], content: "only-content" },
+        userPubkey,
+        RELAYS,
+        undefined,
+        testSigner,
+      );
+      expect(result.totalChunks).toBe(1);
+
+      const fetched = await fetchListBackupFromRelay(
+        10003,
+        userPubkey,
+        RELAYS,
+        1000,
+        testSigner,
+      );
+      expect(fetched.backup).not.toBeNull();
+      expect(fetched.backup!.tags).toEqual([]);
+      expect(fetched.backup!.content).toBe("only-content");
+    },
+    15000,
+  );
+});

--- a/tests/list-backup-roundtrip.test.ts
+++ b/tests/list-backup-roundtrip.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  generateSecretKey,
+  getPublicKey,
+  finalizeEvent,
+  Event,
+  EventTemplate,
+  Filter,
+} from "nostr-tools";
+import { NsecSigner } from "@/lib/signers/NsecSigner";
+
+/**
+ * Byte-for-byte roundtrip test for list backup (bookmarks / pinned notes /
+ * interests).
+ *
+ * Sends a raw NIP-51 event shape (tags + encrypted content blob) through
+ * `saveListBackupToRelay` → `fetchListBackupFromRelay` with the real
+ * compress + encrypt pipeline. Verifies tags and content survive unchanged.
+ */
+
+const secretKey = generateSecretKey();
+const userPubkey = getPublicKey(secretKey);
+const testSigner = new NsecSigner(secretKey);
+
+const eventsByDTag = new Map<string, Event>();
+
+vi.mock("@/lib/store", () => ({
+  useStore: {
+    getState: () => ({ session: null }),
+  },
+}));
+
+vi.mock("@/lib/nostr", () => {
+  type Handlers = {
+    onevent?: (e: Event) => void;
+    oneose?: () => void;
+  };
+  return {
+    getPool: () => ({
+      publish: (relays: string[], event: Event) => {
+        const dTag = event.tags.find((t) => t[0] === "d")?.[1];
+        if (dTag) eventsByDTag.set(dTag, event);
+        return relays.map(() => Promise.resolve());
+      },
+      subscribeMany: (_relays: string[], filter: Filter, handlers: Handlers) => {
+        const dTags = (filter["#d"] as string[] | undefined) || [];
+        const authors = (filter.authors as string[] | undefined) || [];
+        queueMicrotask(() => {
+          for (const dTag of dTags) {
+            const event = eventsByDTag.get(dTag);
+            if (event && (authors.length === 0 || authors.includes(event.pubkey))) {
+              handlers.onevent?.(event);
+            }
+          }
+          handlers.oneose?.();
+        });
+        return { close: () => {} };
+      },
+    }),
+    getExpandedRelayList: (relays: string[]) => relays,
+    getSigner: () => testSigner,
+    signEvent: async (template: EventTemplate) =>
+      finalizeEvent(template, secretKey),
+    DEFAULT_RELAYS: ["wss://relay.test"],
+  };
+});
+
+import {
+  saveListBackupToRelay,
+  fetchListBackupFromRelay,
+} from "@/lib/relayStorage";
+
+const RELAYS = ["wss://relay.test"];
+
+beforeEach(() => {
+  eventsByDTag.clear();
+});
+
+async function makeEncryptedContent(plaintext: string): Promise<string> {
+  // Mirrors what a real NIP-51 private-item list would store: opaque
+  // NIP-44 ciphertext that Mutable must never try to decrypt.
+  return testSigner.nip44Encrypt!(userPubkey, plaintext);
+}
+
+describe("list backup byte-for-byte roundtrip", () => {
+  it.each([
+    { kind: 10003, label: "bookmarks" },
+    { kind: 10001, label: "pinned notes" },
+    { kind: 10015, label: "interests" },
+  ])(
+    "roundtrips tags and ciphertext content for $label (kind $kind)",
+    async ({ kind }) => {
+      const tags: string[][] = [
+        ["e", "a".repeat(64)],
+        ["e", "b".repeat(64), "wss://relay.example"],
+        ["a", "30023:abcd:post-1"],
+        ["t", "nostr"],
+        ["r", "https://example.com/article"],
+      ];
+      // Pretend this is NIP-51 private items encrypted by the source client.
+      const content = await makeEncryptedContent(
+        JSON.stringify([
+          ["e", "c".repeat(64)],
+          ["t", "secret-tag"],
+        ]),
+      );
+
+      const saveResult = await saveListBackupToRelay(
+        kind,
+        { tags, content },
+        userPubkey,
+        RELAYS,
+        `roundtrip-${kind}`,
+        testSigner,
+      );
+      expect(saveResult.savedChunks).toBe(saveResult.totalChunks);
+
+      const fetched = await fetchListBackupFromRelay(
+        kind,
+        userPubkey,
+        RELAYS,
+        1000,
+        testSigner,
+      );
+      expect(fetched.backup).not.toBeNull();
+      expect(fetched.backup!.kind).toBe(kind);
+      // Byte-for-byte equality: we never touched the ciphertext.
+      expect(fetched.backup!.content).toBe(content);
+      expect(fetched.backup!.tags).toEqual(tags);
+      expect(fetched.backup!.notes).toBe(`roundtrip-${kind}`);
+    },
+    15000,
+  );
+
+  it(
+    "rejects unsupported list kinds",
+    async () => {
+      await expect(
+        saveListBackupToRelay(
+          99999,
+          { tags: [], content: "" },
+          userPubkey,
+          RELAYS,
+          undefined,
+          testSigner,
+        ),
+      ).rejects.toThrow(/Unsupported list backup kind/);
+
+      await expect(
+        fetchListBackupFromRelay(99999, userPubkey, RELAYS, 1000, testSigner),
+      ).rejects.toThrow(/Unsupported list backup kind/);
+    },
+    5000,
+  );
+
+  it(
+    "returns backup=null when no chunk 0 is present on any relay",
+    async () => {
+      const fetched = await fetchListBackupFromRelay(
+        10003,
+        userPubkey,
+        RELAYS,
+        500,
+        testSigner,
+      );
+      expect(fetched.backup).toBeNull();
+      expect(fetched.foundOnRelays).toEqual([]);
+    },
+    5000,
+  );
+});


### PR DESCRIPTION
## Summary

Extends the existing relay-backup infrastructure (NIP-78 app data with NIP-44 encryption + gzip compression) to cover three user-owned NIP-51 lists: bookmarks (10003), pinned notes (10001), and interests (10015).

- Each list is stored in its own chunked backup event under a new d-tag prefix (`mutable:bookmarks-backup:N`, etc.). Tags are split into 500-item chunks; the (potentially encrypted) `content` blob is preserved verbatim on chunk 0 only, so NIP-51 private list items round-trip without Mutable ever decrypting them.
- New "Bookmarks & Lists Relay Backup" card with per-kind save / restore / refresh.
- Replaced the standalone "Backup Bookmarks" header button with a "More Backups" scroll link.
- Mute and Follow "Save to Relays" now also write local-history entries, so the Local Backup History timeline is consistent across every type.
- Added a "Local Backup History" heading above the list clarifying that entries live in the browser and can be exported as JSON.
- Version bump to 1.3.0.

## Test plan

- [ ] `npm test` — 24/24 passing (9 new, covering chunking + round-trip for all three kinds)
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run build` — succeeds
- [ ] Manual: create bookmarks list, Save to Relays from Backups tab, confirm encrypted chunks published and Local Backup History row appears
- [ ] Manual: Restore from Relays, confirm republished event matches source (private items intact)
- [ ] Manual: repeat for pinned notes and interests
- [ ] Manual: Save to Relays for mute+follow now also writes a Local Backup History row
- [ ] Manual: "More Backups" link scrolls smoothly to the relay-backup card