### PR TITLE
feat: Muggable — Bitcoin key exposure check (v1.4.0)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -78,6 +78,7 @@ function DashboardContent() {
     "listCleaner",
     "snoopable",
     "clonable",
+    "muggable",
   ] as const;
   const isToolTabActive = toolTabs.includes(activeTab as any);
 
@@ -107,6 +108,7 @@ function DashboardContent() {
       "noteNuke",
       "snoopable",
       "clonable",
+      "muggable",
     ] as const;
 
     if (tabParam && validTabs.includes(tabParam as any)) {
@@ -643,6 +645,17 @@ function DashboardContent() {
                   >
                     Clonable
                   </Link>
+                  <Link
+                    href="/muggable"
+                    onClick={() => setToolsDropdownOpen(false)}
+                    className={`block w-full text-left px-4 py-2.5 text-base font-semibold transition-colors ${
+                      activeTab === "muggable"
+                        ? "bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-400"
+                        : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    }`}
+                  >
+                    Muggable
+                  </Link>
                 </div>
               )}
             </div>
@@ -688,6 +701,7 @@ function DashboardContent() {
                 {activeTab === "listCleaner" && "List Cleaner"}
                 {activeTab === "snoopable" && "Snoopable"}
                 {activeTab === "clonable" && "Clonable"}
+                {activeTab === "muggable" && "Muggable"}
                 {activeTab === "backups" && "Backups"}
                 {activeTab === "settings" && "Settings"}
               </span>
@@ -881,6 +895,17 @@ function DashboardContent() {
                           }`}
                         >
                           Clonable
+                        </Link>
+                        <Link
+                          href="/muggable"
+                          onClick={() => setMobileMenuOpen(false)}
+                          className={`block w-full text-left py-2.5 px-4 rounded-lg font-medium text-sm transition-colors ${
+                            activeTab === "muggable"
+                              ? "bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-400"
+                              : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                          }`}
+                        >
+                          Muggable
                         </Link>
                       </div>
                     )}

--- a/app/muggable/page.tsx
+++ b/app/muggable/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from "react";
+import { Metadata } from "next";
+import MuggableWrapper from "@/components/MuggableWrapper";
+
+export const metadata: Metadata = {
+  title: "Muggable by Mutable: Is your Nostr key holding Bitcoin?",
+  description:
+    "Check if your Nostr identity controls Bitcoin on-chain. A Nostr nsec is also a Bitcoin private key — see your exposure before someone else does.",
+  openGraph: {
+    title: "Muggable by Mutable: Is your Nostr key holding Bitcoin?",
+    description:
+      "Check if your Nostr identity controls Bitcoin on-chain. A Nostr nsec is also a Bitcoin private key — see your exposure before someone else does.",
+    images: ["/muggable_social_card.png"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Muggable by Mutable: Is your Nostr key holding Bitcoin?",
+    description:
+      "Check if your Nostr identity controls Bitcoin on-chain. A Nostr nsec is also a Bitcoin private key — see your exposure before someone else does.",
+    images: ["/muggable_social_card.png"],
+  },
+};
+
+export default function MuggablePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800" />
+      }
+    >
+      <MuggableWrapper />
+    </Suspense>
+  );
+}

--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -18,6 +18,7 @@ type ActivePage =
   | "listCleaner"
   | "snoopable"
   | "clonable"
+  | "muggable"
   | "settings";
 
 interface DashboardNavProps {
@@ -32,6 +33,7 @@ const toolPages: ActivePage[] = [
   "decimator",
   "listCleaner",
   "clonable",
+  "muggable",
 ];
 
 // Map page IDs to display names
@@ -49,6 +51,7 @@ const pageNames: Record<ActivePage, string> = {
   listCleaner: "List Cleaner",
   snoopable: "Snoopable",
   clonable: "Clonable",
+  muggable: "Muggable",
   settings: "Settings",
 };
 
@@ -67,6 +70,7 @@ const pageUrls: Record<ActivePage, string> = {
   listCleaner: "/dashboard?tab=listCleaner",
   snoopable: "/snoopable",
   clonable: "/clonable",
+  muggable: "/muggable",
   settings: "/dashboard?tab=settings",
 };
 

--- a/components/Muggable.tsx
+++ b/components/Muggable.tsx
@@ -1,0 +1,874 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import { useStore } from "@/lib/store";
+import {
+  AlertTriangle,
+  Search,
+  RefreshCw,
+  ExternalLink,
+  Copy,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Wrench,
+  Zap,
+  Shield,
+  User,
+} from "lucide-react";
+import {
+  getExposure,
+  fetchAddressHistory,
+  DEFAULT_ESPLORA_ENDPOINT,
+  ExposureReport,
+  AddressReport,
+  LedgerEntry,
+} from "@/lib/keyExposureService";
+import { hexToNpub, searchProfiles, fetchProfile } from "@/lib/nostr";
+import { getDisplayName, truncateNpub } from "@/lib/utils/format";
+import { Profile } from "@/types";
+
+function satsToBtc(sats: number): string {
+  return (sats / 1e8).toFixed(8);
+}
+
+function formatSats(sats: number): string {
+  return sats.toLocaleString() + " sats";
+}
+
+function formatDate(ts: number | null): string {
+  if (!ts) return "pending";
+  return new Date(ts * 1000).toISOString().slice(0, 10);
+}
+
+function truncateAddr(addr: string): string {
+  if (addr.length <= 20) return addr;
+  return addr.slice(0, 10) + "…" + addr.slice(-8);
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+  return (
+    <button
+      onClick={copy}
+      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+      title="Copy"
+    >
+      {copied ? <Check size={13} /> : <Copy size={13} />}
+    </button>
+  );
+}
+
+function AddressRow({
+  report,
+  endpoint,
+  isPrimary,
+}: {
+  report: AddressReport;
+  endpoint: string;
+  isPrimary: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [history, setHistory] = useState<LedgerEntry[] | null>(null);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+
+  const hasFunds =
+    !report.error && report.confirmedSats + report.unconfirmedSats > 0;
+  const hasActivity = !report.error && report.txCount > 0;
+
+  const toggleHistory = async () => {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+    setExpanded(true);
+    if (history !== null) return;
+    setLoadingHistory(true);
+    setHistoryError(null);
+    try {
+      const entries = await fetchAddressHistory(report.address, endpoint);
+      setHistory(entries);
+    } catch (e) {
+      setHistoryError(e instanceof Error ? e.message : "Failed to load history");
+    } finally {
+      setLoadingHistory(false);
+    }
+  };
+
+  return (
+    <div
+      className={`border rounded-lg overflow-hidden ${
+        isPrimary
+          ? hasFunds
+            ? "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/10"
+            : "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+          : "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+      }`}
+    >
+      <div className="flex items-center gap-3 px-4 py-3">
+        {/* Type badge */}
+        <span
+          className={`text-xs font-mono font-semibold px-2 py-0.5 rounded flex-shrink-0 ${
+            isPrimary
+              ? "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400"
+          }`}
+        >
+          {report.type}
+          {isPrimary && " ★"}
+        </span>
+
+        {/* Address */}
+        <a
+          href={report.addressUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1 min-w-0"
+          title={report.address}
+        >
+          <span className="truncate">{truncateAddr(report.address)}</span>
+          <ExternalLink size={11} className="flex-shrink-0" />
+        </a>
+        <CopyButton text={report.address} />
+
+        <div className="ml-auto flex items-center gap-4 flex-shrink-0">
+          {report.error ? (
+            <span className="text-xs text-gray-400">unavailable</span>
+          ) : (
+            <>
+              <span
+                className={`text-sm font-semibold ${
+                  hasFunds
+                    ? "text-red-600 dark:text-red-400"
+                    : "text-gray-500 dark:text-gray-400"
+                }`}
+              >
+                {formatSats(report.confirmedSats)}
+                {report.unconfirmedSats > 0 && (
+                  <span className="text-xs font-normal ml-1 text-yellow-600 dark:text-yellow-400">
+                    +{formatSats(report.unconfirmedSats)} pending
+                  </span>
+                )}
+              </span>
+              <span className="text-xs text-gray-400">
+                {report.txCount} tx
+              </span>
+              {hasActivity && (
+                <button
+                  onClick={toggleHistory}
+                  className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+                >
+                  {expanded ? (
+                    <ChevronUp size={14} />
+                  ) : (
+                    <ChevronDown size={14} />
+                  )}
+                  history
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Transaction history */}
+      {expanded && (
+        <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-3">
+          {loadingHistory && (
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <RefreshCw size={13} className="animate-spin" />
+              Loading history…
+            </div>
+          )}
+          {historyError && (
+            <p className="text-sm text-red-500">{historyError}</p>
+          )}
+          {history && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs font-mono">
+                <thead>
+                  <tr className="text-gray-400 text-left">
+                    <th className="pb-1 pr-4">Date</th>
+                    <th className="pb-1 pr-4 text-right">Delta</th>
+                    <th className="pb-1 pr-4 text-right">Balance</th>
+                    <th className="pb-1">Txid</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {history.map((entry) => (
+                    <tr key={entry.txid} className="border-t border-gray-100 dark:border-gray-700">
+                      <td className="py-1 pr-4 text-gray-500">
+                        {formatDate(entry.time)}
+                      </td>
+                      <td
+                        className={`py-1 pr-4 text-right ${
+                          entry.deltaSats >= 0
+                            ? "text-green-600 dark:text-green-400"
+                            : "text-red-600 dark:text-red-400"
+                        }`}
+                      >
+                        {entry.deltaSats >= 0 ? "+" : ""}
+                        {entry.deltaSats.toLocaleString()}
+                      </td>
+                      <td className="py-1 pr-4 text-right text-gray-700 dark:text-gray-300">
+                        {entry.runningSats.toLocaleString()}
+                      </td>
+                      <td className="py-1">
+                        <a
+                          href={entry.txUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+                        >
+                          {entry.txid.slice(0, 12)}…
+                          <ExternalLink size={10} />
+                        </a>
+                        {!entry.confirmed && (
+                          <span className="text-yellow-500 ml-1">(pending)</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SweepGuide() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border border-yellow-200 dark:border-yellow-800 rounded-xl overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-yellow-50 dark:bg-yellow-900/20 text-left"
+      >
+        <div className="flex items-center gap-2">
+          <Zap size={16} className="text-yellow-500 dark:text-yellow-400 flex-shrink-0" />
+          <span className="font-semibold text-sm text-yellow-900 dark:text-yellow-200">
+            How to sweep these funds to safety
+          </span>
+        </div>
+        {open ? (
+          <ChevronUp size={15} className="text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
+        ) : (
+          <ChevronDown size={15} className="text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
+        )}
+      </button>
+
+      {open && (
+        <div className="px-5 py-4 space-y-4 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300">
+          <p>
+            Your <strong>nsec is the Bitcoin private key</strong>. Decoded from
+            bech32, it is a 32-byte secp256k1 scalar — the same private key
+            that controls the on-chain funds shown above. To move those funds
+            to a safe wallet, import this key into a Bitcoin wallet that
+            understands Taproot.
+          </p>
+
+          <div className="space-y-3">
+            <p className="font-semibold text-gray-900 dark:text-white">
+              Using Sparrow Wallet (recommended)
+            </p>
+            <ol className="space-y-2 list-none">
+              {[
+                <>Download and open <a href="https://sparrowwallet.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">Sparrow Wallet</a>.</>,
+                <>File → <strong>New Wallet</strong>, give it a temporary name.</>,
+                <>Under <strong>Script Type</strong>, choose <strong>Taproot (P2TR)</strong>.</>,
+                <>Under <strong>Keystore 1</strong>, click <strong>New or Imported Software Wallet</strong>.</>,
+                <>Choose <strong>Master Private Key (WIF)</strong>. Convert your nsec to WIF format (see below), paste it in, and click Import.</>,
+                <>Sparrow will derive the same Taproot address shown above. Verify the address matches before proceeding.</>,
+                <>Create a <strong>Send</strong> transaction to sweep the full balance to a fresh wallet address you control.</>,
+                <>Once swept, consider generating a new Nostr key pair so your identity key is never a funded Bitcoin address again.</>,
+              ].map((step, i) => (
+                <li key={i} className="flex gap-3">
+                  <span className="flex-shrink-0 w-5 h-5 rounded-full bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300 text-xs font-bold flex items-center justify-center">
+                    {i + 1}
+                  </span>
+                  <span className="leading-relaxed">{step}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 space-y-1">
+            <p className="font-semibold text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              nsec → WIF conversion
+            </p>
+            <p className="text-xs text-gray-600 dark:text-gray-400 leading-relaxed">
+              Decode your nsec from bech32 to get the 32-byte hex private key.
+              Prepend <code className="bg-gray-200 dark:bg-gray-600 px-1 rounded">0x80</code>,
+              append <code className="bg-gray-200 dark:bg-gray-600 px-1 rounded">0x01</code> (compressed),
+              then base58check-encode the result. The <code className="bg-gray-200 dark:bg-gray-600 px-1 rounded">ian coleman bip39</code> tool
+              and <code className="bg-gray-200 dark:bg-gray-600 px-1 rounded">wif.fly.dev</code> can do this
+              conversion offline. <strong>Never paste your nsec into an online tool.</strong>
+            </p>
+          </div>
+
+          <div className="flex items-start gap-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+            <AlertTriangle size={14} className="text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+            <p className="text-xs text-red-700 dark:text-red-300 leading-relaxed">
+              Your nsec is your most sensitive secret. Only enter it into
+              software you trust, on a device you own, while offline if
+              possible. Mutable never asks for your nsec.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ResultsCard({
+  report,
+  endpoint,
+  profile,
+}: {
+  report: ExposureReport;
+  endpoint: string;
+  profile: Profile | null;
+}) {
+  const [showSecondary, setShowSecondary] = useState(false);
+  const isFunded = report.totalSats > 0;
+
+  const primaryAddr = report.addresses.find((a) => a.type === "P2TR");
+  const secondaryAddrs = report.addresses.filter((a) => a.type !== "P2TR");
+
+  const fetchedAt = new Date(report.fetchedAt).toUTCString();
+
+  return (
+    <div className="space-y-4">
+      {/* Total summary */}
+      {isFunded ? (
+        <div className="bg-green-50 dark:bg-green-900/20 border border-green-300 dark:border-green-700 rounded-xl p-4 space-y-3">
+          <div className="flex items-center gap-3">
+            {profile?.picture ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={profile.picture}
+                alt=""
+                className="w-11 h-11 rounded-full object-cover flex-shrink-0"
+                onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+              />
+            ) : (
+              <div className="w-11 h-11 rounded-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center flex-shrink-0">
+                <User size={20} className="text-white" />
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="font-semibold text-green-900 dark:text-green-100 truncate">
+                {profile ? getDisplayName(profile) : truncateNpub(report.npub)}
+              </p>
+              {profile?.nip05 && (
+                <p className="text-xs text-green-700 dark:text-green-300 truncate">
+                  ✓ {profile.nip05}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-start gap-2 border-t border-green-200 dark:border-green-700 pt-3">
+            <AlertTriangle size={16} className="text-green-700 dark:text-green-300 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="font-semibold text-green-900 dark:text-green-100 text-sm">
+                Muggable — this key controls Bitcoin
+              </p>
+              <p className="text-sm text-green-800 dark:text-green-200 mt-0.5">
+                {satsToBtc(report.totalSats)} BTC ({formatSats(report.totalSats)})
+                — an exposed nsec can be swept.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-4 space-y-3">
+          <div className="flex items-center gap-3">
+            {profile?.picture ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={profile.picture}
+                alt=""
+                className="w-11 h-11 rounded-full object-cover flex-shrink-0"
+                onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+              />
+            ) : (
+              <div className="w-11 h-11 rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center flex-shrink-0">
+                <User size={20} className="text-white" />
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="font-semibold text-blue-900 dark:text-blue-100 truncate">
+                {profile ? getDisplayName(profile) : truncateNpub(report.npub)}
+              </p>
+              {profile?.nip05 && (
+                <p className="text-xs text-blue-700 dark:text-blue-300 truncate">
+                  ✓ {profile.nip05}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 border-t border-blue-200 dark:border-blue-700 pt-3">
+            <Shield size={16} className="text-blue-600 dark:text-blue-400 flex-shrink-0" />
+            <p className="text-sm text-blue-800 dark:text-blue-200">
+              No funds found across all derived addresses.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Identity info */}
+      <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg px-4 py-3 text-xs font-mono text-gray-500 dark:text-gray-400 space-y-1">
+        <div className="flex items-center gap-2">
+          <span className="text-gray-400">npub</span>
+          <span className="text-gray-700 dark:text-gray-300 break-all">
+            {report.npub}
+          </span>
+          <CopyButton text={report.npub} />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-gray-400">hex</span>
+          <span className="text-gray-700 dark:text-gray-300 break-all">
+            {report.pubkeyHex}
+          </span>
+          <CopyButton text={report.pubkeyHex} />
+        </div>
+      </div>
+
+      {/* Primary address (P2TR canonical) */}
+      {primaryAddr && (
+        <div>
+          <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2">
+            Canonical Taproot address (BIP341 key-path)
+          </p>
+          <AddressRow
+            report={primaryAddr}
+            endpoint={endpoint}
+            isPrimary={true}
+          />
+        </div>
+      )}
+
+      {/* Secondary addresses */}
+      <div>
+        <button
+          onClick={() => setShowSecondary(!showSecondary)}
+          className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors mb-2"
+        >
+          {showSecondary ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+          {showSecondary ? "Hide" : "Show"} {secondaryAddrs.length} legacy /
+          secondary addresses
+          {secondaryAddrs.some(
+            (a) => !a.error && a.confirmedSats + a.unconfirmedSats > 0
+          ) && (
+            <span className="ml-1 text-red-500">⚠ some funded</span>
+          )}
+        </button>
+
+        {showSecondary && (
+          <div className="space-y-2">
+            {secondaryAddrs.map((addr) => (
+              <AddressRow
+                key={addr.type}
+                report={addr}
+                endpoint={endpoint}
+                isPrimary={false}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Sweep guide — only when funded */}
+      {isFunded && <SweepGuide />}
+
+      {/* Source + timestamp */}
+      <p className="text-xs text-gray-400 dark:text-gray-500">
+        Source:{" "}
+        <a
+          href={report.source}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          {report.source}
+        </a>{" "}
+        · Fetched at {fetchedAt}
+      </p>
+    </div>
+  );
+}
+
+export default function Muggable() {
+  const { session } = useAuth();
+  const { userProfile } = useStore();
+  const searchParams = useSearchParams();
+
+  const [input, setInput] = useState("");
+  const [endpoint, setEndpoint] = useState(DEFAULT_ESPLORA_ENDPOINT);
+  const [checking, setChecking] = useState(false);
+  const [progress, setProgress] = useState<{
+    phase: string;
+    current: number;
+    total: number;
+  } | null>(null);
+  const [report, setReport] = useState<ExposureReport | null>(null);
+  const [checkedProfile, setCheckedProfile] = useState<Profile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<boolean>(false);
+
+  // Profile search
+  const [searchResults, setSearchResults] = useState<Profile[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Profile search with debounce
+  useEffect(() => {
+    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+
+    if (
+      !input.trim() ||
+      input.startsWith("npub") ||
+      input.startsWith("nprofile") ||
+      /^[0-9a-f]{64}$/i.test(input) ||
+      input.includes(".")
+    ) {
+      setSearchResults([]);
+      setShowDropdown(false);
+      return;
+    }
+
+    searchTimeoutRef.current = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const results = await searchProfiles(input, session?.relays, 10);
+        setSearchResults(results);
+        setShowDropdown(results.length > 0);
+      } catch {
+        // silently ignore search errors
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
+
+    return () => {
+      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    };
+  }, [input, session?.relays]);
+
+  // Pre-populate from URL param only
+  useEffect(() => {
+    const npubParam = searchParams.get("npub");
+    if (npubParam) {
+      setInput(npubParam);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSelectProfile = (profile: Profile) => {
+    const npub = hexToNpub(profile.pubkey);
+    setInput(npub);
+    setShowDropdown(false);
+    setSearchResults([]);
+    handleCheckWith(npub);
+  };
+
+  const handleCheckWith = async (query: string) => {
+    if (!query.trim()) return;
+
+    setChecking(true);
+    setError(null);
+    setReport(null);
+    setCheckedProfile(null);
+    setProgress(null);
+    setShowDropdown(false);
+    abortRef.current = false;
+
+    try {
+      const result = await getExposure(query, endpoint, (phase, current, total) => {
+        if (!abortRef.current) {
+          setProgress({ phase, current, total });
+        }
+      });
+      if (!abortRef.current) {
+        setReport(result);
+        // Fetch profile in the background — non-blocking
+        fetchProfile(result.pubkeyHex, session?.relays).then((p) => {
+          if (!abortRef.current) setCheckedProfile(p);
+        }).catch(() => {});
+      }
+    } catch (e) {
+      if (!abortRef.current) {
+        setError(e instanceof Error ? e.message : "Unknown error");
+      }
+    } finally {
+      setChecking(false);
+      setProgress(null);
+    }
+  };
+
+  const handleCheck = async () => {
+    let query = input.trim();
+    if (!query) return;
+
+    // If the input looks like a name (not npub/hex/nip05), resolve it first
+    if (
+      !query.startsWith("npub") &&
+      !query.startsWith("nprofile") &&
+      !/^[0-9a-f]{64}$/i.test(query) &&
+      !query.includes(".")
+    ) {
+      const profiles = await searchProfiles(query, session?.relays, 1);
+      if (!profiles.length) {
+        setError("Could not find a user matching that name.");
+        return;
+      }
+      query = hexToNpub(profiles[0].pubkey);
+      setInput(query);
+    }
+
+    handleCheckWith(query);
+  };
+
+  const handleStop = () => {
+    abortRef.current = true;
+    setChecking(false);
+    setProgress(null);
+  };
+
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-3 mb-2">
+          <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg">
+            <Wrench size={22} className="text-red-600 dark:text-red-400" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Muggable
+          </h1>
+        </div>
+        <p className="text-gray-600 dark:text-gray-400 text-sm">
+          Check whether a Nostr identity controls Bitcoin on-chain. A Nostr
+          public key is a secp256k1 key — the same curve Bitcoin uses. Anyone
+          who knows your npub can derive your Bitcoin addresses.
+        </p>
+      </div>
+
+      {/* Warning: on-chain zaps */}
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <AlertTriangle
+            size={18}
+            className="text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5"
+          />
+          <div>
+            <p className="font-semibold text-red-900 dark:text-red-200 text-sm">
+              On-chain Bitcoin zaps are a privacy trap
+            </p>
+            <p className="text-sm text-red-800 dark:text-red-300 mt-1 leading-relaxed">
+              When anyone sends you Bitcoin on-chain using your Nostr key, it
+              creates a <strong>permanent, public, immutable</strong> record on
+              the Bitcoin blockchain. Because your address is deterministically
+              derived from your public key, senders do not need your permission
+              — they can fund your address without you asking for it. Every
+              transaction is forever visible to everyone, linking your Nostr
+              identity to your full financial history.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-start gap-3 border-t border-yellow-200 dark:border-yellow-800 pt-3">
+          <Zap
+            size={16}
+            className="text-yellow-500 dark:text-yellow-400 flex-shrink-0 mt-0.5"
+          />
+          <p className="text-sm text-yellow-900 dark:text-yellow-200">
+            <strong>Use Lightning zaps instead.</strong> Lightning payments
+            route through channels and do not create a permanent on-chain record
+            tied to your Nostr identity. They are faster, cheaper, and private.
+          </p>
+        </div>
+      </div>
+
+      {/* Input */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 space-y-4">
+        <div className="relative">
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search
+                size={15}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+              />
+              <input
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && !checking && handleCheck()}
+                onFocus={() => searchResults.length > 0 && setShowDropdown(true)}
+                placeholder="npub1… / username / NIP-05 / hex"
+                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-red-500 font-mono"
+                disabled={checking}
+              />
+              {isSearching && (
+                <RefreshCw
+                  size={13}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 animate-spin pointer-events-none"
+                />
+              )}
+            </div>
+            {checking ? (
+              <button
+                onClick={handleStop}
+                className="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors flex items-center gap-2"
+              >
+                Stop
+              </button>
+            ) : (
+              <>
+                <button
+                  onClick={handleCheck}
+                  disabled={!input.trim()}
+                  className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+                >
+                  <Search size={15} />
+                  Check
+                </button>
+                {session && (
+                  <button
+                    onClick={() => {
+                      try {
+                        const npub = hexToNpub(session.pubkey);
+                        setInput(npub);
+                        handleCheckWith(npub);
+                      } catch {
+                        // ignore
+                      }
+                    }}
+                    className="px-4 py-2 text-sm border border-red-400 dark:border-red-600 text-red-600 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors flex items-center gap-2 whitespace-nowrap"
+                  >
+                    <User size={15} />
+                    Check me
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Search dropdown */}
+          {showDropdown && searchResults.length > 0 && (
+            <div className="absolute z-50 left-0 right-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-64 overflow-y-auto">
+              {searchResults.map((profile) => (
+                <button
+                  key={profile.pubkey}
+                  onClick={() => handleSelectProfile(profile)}
+                  className="w-full px-4 py-3 flex items-center gap-3 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-left"
+                >
+                  {profile.picture ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={profile.picture}
+                      alt=""
+                      className="w-9 h-9 rounded-full object-cover flex-shrink-0"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).src = `https://api.dicebear.com/7.x/bottts/svg?seed=${profile.pubkey}`;
+                      }}
+                    />
+                  ) : (
+                    <div className="w-9 h-9 rounded-full bg-gradient-to-br from-red-400 to-red-500 flex items-center justify-center flex-shrink-0">
+                      <User size={16} className="text-white" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-sm text-gray-900 dark:text-white truncate">
+                      {getDisplayName(profile)}
+                    </div>
+                    {profile.nip05 && (
+                      <div className="text-xs text-green-600 dark:text-green-400 truncate">
+                        ✓ {profile.nip05}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Advanced: custom endpoint */}
+        <details className="text-xs">
+          <summary className="cursor-pointer text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+            Advanced options
+          </summary>
+          <div className="mt-2 flex items-center gap-2">
+            <label className="text-gray-500 dark:text-gray-400 whitespace-nowrap">
+              Esplora endpoint
+            </label>
+            <input
+              type="text"
+              value={endpoint}
+              onChange={(e) => setEndpoint(e.target.value)}
+              className="flex-1 px-2 py-1 border border-gray-200 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-mono"
+            />
+          </div>
+          <p className="mt-1 text-gray-400">
+            Point to your own Esplora instance for privacy. Queries leak the
+            looked-up addresses to the configured endpoint.
+          </p>
+        </details>
+      </div>
+
+      {/* Loading */}
+      {checking && (
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5">
+          <div className="flex items-center gap-3 mb-3">
+            <RefreshCw
+              size={16}
+              className="animate-spin text-red-500"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              {progress
+                ? `Checking ${progress.phase}… (${progress.current}/${progress.total})`
+                : "Resolving identity…"}
+            </span>
+          </div>
+          {progress && (
+            <div className="h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-red-500 transition-all duration-300"
+                style={{
+                  width: `${(progress.current / progress.total) * 100}%`,
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4 text-sm text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Results */}
+      {report && (
+        <ResultsCard report={report} endpoint={endpoint} profile={checkedProfile} />
+      )}
+    </div>
+  );
+}

--- a/components/MuggableWrapper.tsx
+++ b/components/MuggableWrapper.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import { User, LogOut } from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+import { useAuth } from "@/hooks/useAuth";
+import { useStore } from "@/lib/store";
+import Muggable from "./Muggable";
+import Footer from "./Footer";
+import DashboardNav from "./DashboardNav";
+import { Profile } from "@/types";
+import UserProfileModal from "./UserProfileModal";
+import GlobalUserSearch from "./GlobalUserSearch";
+import AuthModal from "./AuthModal";
+
+export default function MuggableWrapper() {
+  const { session, disconnect } = useAuth();
+  const { userProfile } = useStore();
+  const [selectedProfile, setSelectedProfile] = useState<Profile | null>(null);
+  const [showAuthModal, setShowAuthModal] = useState(false);
+
+  const handleDisconnect = () => {
+    disconnect();
+    window.location.href = "/";
+  };
+
+  const handleUserSelect = (profile: Profile) => {
+    setSelectedProfile(profile);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
+      {session ? (
+        <>
+          <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="flex justify-between items-center h-16 gap-4">
+                <Link
+                  href="/dashboard"
+                  className="flex items-center space-x-3 flex-shrink-0 hover:opacity-80 transition-opacity"
+                  title="Go to Dashboard"
+                >
+                  <Image
+                    src="/mutable_logo.svg"
+                    alt="Mutable"
+                    width={40}
+                    height={40}
+                  />
+                  <Image
+                    src="/mutable_text.svg"
+                    alt="Mutable"
+                    width={120}
+                    height={24}
+                    className="hidden sm:block"
+                  />
+                </Link>
+
+                <GlobalUserSearch onSelectUser={handleUserSelect} />
+
+                <div className="flex items-center space-x-4 flex-shrink-0">
+                  <div className="hidden md:flex items-center space-x-3">
+                    {userProfile?.picture ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={userProfile.picture}
+                        alt={
+                          userProfile.display_name || userProfile.name || "User"
+                        }
+                        className="w-8 h-8 rounded-full object-cover"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).src =
+                            'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"%3E%3Ccircle cx="12" cy="12" r="10"/%3E%3Cpath d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"/%3E%3Cpath d="M4 20c0-4 3.6-6 8-6s8 2 8 6"/%3E%3C/svg%3E';
+                        }}
+                      />
+                    ) : (
+                      <div className="w-8 h-8 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center">
+                        <User
+                          size={16}
+                          className="text-gray-600 dark:text-gray-300"
+                        />
+                      </div>
+                    )}
+                    <div className="flex flex-col">
+                      {userProfile && (
+                        <>
+                          <span className="text-sm font-medium text-gray-900 dark:text-white">
+                            {userProfile.display_name ||
+                              userProfile.name ||
+                              "Anonymous"}
+                          </span>
+                          {userProfile.nip05 && (
+                            <span className="text-xs text-gray-600 dark:text-gray-400">
+                              {userProfile.nip05}
+                            </span>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="md:hidden">
+                    {userProfile?.picture ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={userProfile.picture}
+                        alt={
+                          userProfile.display_name || userProfile.name || "User"
+                        }
+                        className="w-8 h-8 rounded-full object-cover"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).src =
+                            'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"%3E%3Ccircle cx="12" cy="12" r="10"/%3E%3Cpath d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"/%3E%3Cpath d="M4 20c0-4 3.6-6 8-6s8 2 8 6"/%3E%3C/svg%3E';
+                        }}
+                      />
+                    ) : (
+                      <div className="w-8 h-8 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center">
+                        <User
+                          size={16}
+                          className="text-gray-600 dark:text-gray-300"
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  <button
+                    onClick={handleDisconnect}
+                    className="flex items-center space-x-2 px-4 py-2 text-sm text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                    title="Disconnect"
+                  >
+                    <LogOut size={16} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <DashboardNav activePage="muggable" />
+        </>
+      ) : (
+        <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex justify-between items-center h-16 gap-4">
+              <Link
+                href="/"
+                className="flex items-center space-x-3 flex-shrink-0 hover:opacity-80 transition-opacity"
+                title="Go to Home"
+              >
+                <Image
+                  src="/mutable_logo.svg"
+                  alt="Mutable"
+                  width={40}
+                  height={40}
+                />
+                <Image
+                  src="/mutable_text.svg"
+                  alt="Mutable"
+                  width={120}
+                  height={24}
+                  className="hidden sm:block"
+                />
+              </Link>
+
+              <div className="flex-1" />
+
+              <div className="flex items-center gap-3">
+                <span className="hidden md:inline text-sm text-gray-600 dark:text-gray-400">
+                  Sign in for more features
+                </span>
+                <button
+                  onClick={() => setShowAuthModal(true)}
+                  className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors font-medium flex items-center gap-2"
+                >
+                  <User size={16} />
+                  Connect with Nostr
+                </button>
+              </div>
+            </div>
+          </div>
+        </header>
+      )}
+
+      <div className="flex-1 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800">
+        <main className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow">
+          <Muggable />
+        </main>
+      </div>
+
+      <Footer />
+
+      {selectedProfile && (
+        <UserProfileModal
+          profile={selectedProfile}
+          onClose={() => setSelectedProfile(null)}
+        />
+      )}
+
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+      />
+    </div>
+  );
+}

--- a/docs/muggable-plan.md
+++ b/docs/muggable-plan.md
@@ -1,0 +1,76 @@
+# Muggable Plan
+
+> **Muggable** is the user-facing name for this feature. The precise technical
+> concept is *key exposure* via *key sweep* — that language is kept in code,
+> types, and APIs (`keyExposureService`, `ExposureReport`). "Muggable" is the
+> brand in UI copy and docs headings.
+
+## Goal
+Add **Muggable** — a key-exposure check — to Mutable: given a Nostr identity (npub / nprofile / NIP‑05 / hex), surface whether that identity's public key also controls **Bitcoin** on‑chain. The point is defensive awareness — a Nostr key is an secp256k1 key, so an `nsec` is also a Bitcoin private key. Users should be able to see this risk for their own account, the same way Mutable already helps them audit their mute footprint.
+
+## Background
+A Nostr pubkey is a 32‑byte x‑only secp256k1 key. The same key maps to spendable Bitcoin addresses. The dominant, real‑world surface is the **canonical BIP341 Taproot key‑path address**: the address encodes the *tweaked* output key `Q = P + tagged_hash("TapTweak", P)·G`, **not** the raw internal key. Naive "nostr = bitcoin" demos that encode the raw x‑only key as a P2TR program look at the wrong (always‑empty) address and conclude there is nothing there. Encoding the canonical tweaked key reveals that many identities hold real sats.
+
+This was validated against the OPENETR reference app: internal key `0461fcbe…` → tweak `1619853a…` → output key `637b9141…` → `bc1pvdaezs0…`, a live, actively‑used wallet. The reference implementation reproduces those exact values (regression‑locked in its `--selftest`).
+
+## Proposed Feature
+- Input: any identity Mutable already understands (npub, nprofile, NIP‑05, bare domain, hex). Reuse the existing `nostr-tools` / `bech32` decode path in `lib/utils/nostrHelpers.ts` — do **not** re‑implement bech32.
+- Derive candidate Bitcoin addresses from the x‑only key and report any balance.
+- Primary, must‑have derivation: **canonical BIP341 key‑path P2TR**. Secondary (completeness): P2PKH/P2WPKH/P2SH‑P2WPKH for both Y‑parities, and uncompressed P2PKH.
+- **Full balance history for any key.** For every address with activity, walk the *complete* on‑chain history and present a per‑transaction ledger: date, signed delta, and a **running balance**. This is not a single snapshot — the whole timeline is shown.
+- **Explorer links everywhere.** Every derived address and every transaction links out to the configured block explorer (mempool.space by default): `…/address/<addr>` and `…/tx/<txid>`. Users can verify and dig in independently.
+- Read‑only and key‑safe: only the **public** key and **public** chain data are ever touched. This preserves Mutable's "client‑side only, no private keys" principle.
+
+## Derivation Notes
+- The BIP341 tweak needs secp256k1 point math. In the TS port use a vetted library (**`@noble/curves/secp256k1`**, or the curve primitives already vendored by `nostr-tools`). Do not hand‑roll EC in production — the Python prototype hand‑rolls it only because it is stdlib‑only.
+- Y‑parity of a Nostr x‑only key is unknown to Bitcoin, so every hash160‑based type has two candidates (`0x02`/`0x03`). Taproot is parity‑independent.
+
+## Data Source for Balances (Choose One or Combine)
+1) **Esplora API** (`mempool.space` / `blockstream.info`) — same source as the reference app. `GET /api/address/<addr>` for balance; `GET /api/address/<addr>/txs/chain[/<last_txid>]` (25 at a time, paginate to walk the *full* history) plus `…/txs/mempool` for pending. The web link base is the API base minus `/api`. Pros: accurate, no key. Cons: third‑party, rate limits, privacy of lookups (see below).
+2) **User‑configurable Esplora endpoint** — let advanced users point at their own instance. Pros: privacy, no shared rate limit. Cons: setup friction.
+3) **Bundled multi‑explorer fallback** — rotate explorers on failure/limit. Pros: resilience. Cons: more surface to maintain.
+
+## UI Placement
+- A new **Muggable** card in the analysis surface (alongside Mute‑o‑Scope), and a non‑blocking **"Muggable" safety badge** on the signed‑in user's account area when their key holds funds.
+- Example summary: "⚠ Muggable — your key controls Bitcoin: 0.00500171 BTC across 2 addresses (canonical Taproot + legacy). An exposed nsec can be swept."
+- Always show: derived address(es), per‑address balance + tx count, the derivation type, and the balance source + fetch time (mirror the transparency ethos of `mute-signal-plan.md`).
+- Each address row links to the explorer and expands into its **full transaction ledger** (date, ± delta, running balance, per‑tx explorer link). Default collapsed; expand on demand so the card stays scannable for high‑activity keys.
+
+## UX Flow
+- On lookup: resolve identity → derive addresses → query balances → render card.
+- Signed‑in self‑check is the headline use case: frame it as a **warning to the user about their own exposure**, with a short explainer and a "how to protect yourself" link.
+- If balances can't be fetched: show derived addresses with balance "—" and a retry, never a hard error.
+
+## Data Model / State
+- New service `lib/keyExposureService.ts`: `deriveAddresses(xonlyHex) -> {type,address}[]` and `getExposure(identity) -> ExposureReport`.
+- `ExposureReport`: `{ input, resolvedVia, pubkeyHex, npub, addresses: AddressReport[], totalSats }`.
+- `AddressReport`: `{ type, address, addressUrl, confirmedSats, unconfirmedSats, txCount, history?: LedgerEntry[] }`.
+- `LedgerEntry`: `{ txid, txUrl, confirmed, height, time, deltaSats, runningSats }` — ordered oldest→newest so `runningSats` reconciles to the reported balance.
+- Component state for the card: `report | null`, `loading`, `source`, `fetchedAt`.
+
+## Security, Ethics & Privacy
+- **Self‑check first.** The primary, recommended framing is helping users discover *their own* exposure. This is consistent with Mutable being an account‑hygiene tool.
+- **Dual‑use.** Looking up arbitrary identities reveals their on‑chain balance. This is public data, but aggregating it into a one‑click "is this person holding sats" tool is sensitive. Scope decision needed (see open questions): gate arbitrary lookups, rate‑limit, or self‑only.
+- **No private keys.** The feature must never request or handle an `nsec`. Public key + public chain only.
+- **Lookup privacy.** Address queries leak the looked‑up identity to the explorer. Document this; consider the user‑configurable endpoint (data source option 2).
+
+## Reference Implementation
+`docs/prototypes/nip05-btc-balance.py` — a working, stdlib‑only Python prototype that this feature ports from. It implements identity resolution (NIP‑05/npub/nprofile/hex), all derivations above, the canonical BIP341 tweak, Esplora balance lookup, explorer links for every address/tx, and (via `--history`) the full paginated per‑address ledger with a running balance. Its `--selftest` is regression‑locked to BIP173 vectors **and** the OPENETR Taproot vector — port the test vectors verbatim into `tests/`.
+
+## Implementation Steps (Future Work)
+1) Add `@noble/curves` (or confirm `nostr-tools` exposes the needed primitives).
+2) Port `deriveAddresses` to `lib/keyExposureService.ts`, reusing existing identity decode helpers.
+3) Port the prototype's selftest vectors into a `vitest` spec in `tests/` (BIP173 + OPENETR BIP341).
+4) Add Esplora client with a configurable endpoint + graceful failure, incl. paginated tx history and explorer link building.
+5) Build the Muggable card + signed‑in safety badge, with per‑address explorer links and an expandable full‑history ledger (running balance).
+6) Resolve the dual‑use scope decision before exposing arbitrary‑identity lookup in the UI.
+7) Add explainer copy + a "protect your key" help link.
+
+## Open Questions
+- Arbitrary‑identity lookups: allow, gate, or self‑only for v1?
+- Default Esplora endpoint, and do we ship a fallback rotation?
+- Surface this passively (badge only) or as a full analysis card from launch?
+
+## Notes
+- Balances are live; an actively‑used wallet's number changes between snapshots. Always show fetch time; never imply precision beyond the snapshot.
+- The canonical Taproot address is the one that matters in practice — legacy/segwit derivations are included for completeness but are usually empty.

--- a/docs/prototypes/nip05-btc-balance.py
+++ b/docs/prototypes/nip05-btc-balance.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+nip05-btc-balance — query a Nostr identity and report any Bitcoin balance.
+
+Reproduces the utility described in note15fqa0w8d230ksr0t5me8rvvrupsmx8s03fayuf9kztrv9yd7afls79ngjx:
+a Nostr pubkey is an secp256k1 x-only key, i.e. also a Bitcoin key. Resolve a
+NIP-05 address (or npub / nprofile / raw hex) to its pubkey, derive the Bitcoin
+addresses that key controls, and check the chain for a balance.
+
+The point is defensive awareness: your nsec is a Bitcoin private key too.
+
+Usage:
+    ./nip05-btc-balance.py <identity> [<identity> ...]
+    ./nip05-btc-balance.py --history <identity>     full tx/balance ledger
+    ./nip05-btc-balance.py --json [--history] <identity>
+    ./nip05-btc-balance.py --selftest
+
+Every address and transaction is reported with an explorer (mempool.space)
+link. --history walks the full chain history per address with a running
+balance.
+
+<identity> is any of:
+    name@domain.com        NIP-05 address
+    domain.com             NIP-05 "_" root identity
+    npub1...               NIP-19 npub
+    nprofile1...           NIP-19 nprofile
+    <64-hex>               raw x-only pubkey
+
+Stdlib only. Read-only (HTTPS GET to the domain's nostr.json and mempool.space).
+"""
+import sys, json, hashlib, urllib.request, urllib.parse, time
+
+EXPLORER = "https://mempool.space/api"
+UA = {"User-Agent": "nip05-btc-balance/1.0 (+defensive-research)"}
+
+# ---------- bech32 / bech32m (BIP173 + BIP350 reference) ----------
+CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+def _polymod(values):
+    GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    chk = 1
+    for v in values:
+        b = chk >> 25
+        chk = ((chk & 0x1ffffff) << 5) ^ v
+        for i in range(5):
+            chk ^= GEN[i] if ((b >> i) & 1) else 0
+    return chk
+
+def _hrp_expand(hrp):
+    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+
+def _checksum(hrp, data, spec):
+    const = 0x2bc830a3 if spec == "bech32m" else 1
+    pm = _polymod(_hrp_expand(hrp) + data + [0] * 6) ^ const
+    return [(pm >> 5 * (5 - i)) & 31 for i in range(6)]
+
+def bech32_encode(hrp, data, spec):
+    combined = data + _checksum(hrp, data, spec)
+    return hrp + "1" + "".join(CHARSET[d] for d in combined)
+
+def bech32_decode(bech):
+    bech = bech.strip().lower()
+    pos = bech.rfind("1")
+    if pos < 1 or pos + 7 > len(bech):
+        raise ValueError("malformed bech32")
+    hrp = bech[:pos]
+    data = [CHARSET.find(c) for c in bech[pos + 1:]]
+    if -1 in data:
+        raise ValueError("bad bech32 char")
+    for spec in ("bech32", "bech32m"):
+        const = 0x2bc830a3 if spec == "bech32m" else 1
+        if _polymod(_hrp_expand(hrp) + data) == const:
+            return hrp, data[:-6]
+    raise ValueError("bad bech32 checksum")
+
+def convertbits(data, frm, to, pad=True):
+    acc = bits = 0
+    ret = []
+    maxv = (1 << to) - 1
+    for value in data:
+        acc = (acc << frm) | value
+        bits += frm
+        while bits >= to:
+            bits -= to
+            ret.append((acc >> bits) & maxv)
+    if pad and bits:
+        ret.append((acc << (to - bits)) & maxv)
+    elif not pad and (bits >= frm or ((acc << (to - bits)) & maxv)):
+        raise ValueError("non-zero padding in bech32 data")
+    return ret
+
+def segwit_addr(hrp, witver, witprog):
+    spec = "bech32" if witver == 0 else "bech32m"
+    return bech32_encode(hrp, [witver] + convertbits(list(witprog), 8, 5), spec)
+
+# ---------- base58check ----------
+_B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+def b58encode(b):
+    n = int.from_bytes(b, "big")
+    s = ""
+    while n:
+        n, r = divmod(n, 58)
+        s = _B58[r] + s
+    pad = len(b) - len(b.lstrip(b"\x00"))
+    return "1" * pad + s
+
+def b58check(payload):
+    chk = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+    return b58encode(payload + chk)
+
+def hash160(b):
+    try:
+        return hashlib.new("ripemd160", hashlib.sha256(b).digest()).digest()
+    except (ValueError, TypeError):
+        sys.exit("error: this Python build lacks RIPEMD-160 (OpenSSL legacy "
+                 "provider disabled); cannot derive Bitcoin addresses.")
+
+# ---------- nostr identity -> 32-byte x-only pubkey (hex) ----------
+def resolve_nip05(addr):
+    local, domain = addr.split("@", 1) if "@" in addr else ("_", addr)
+    url = f"https://{domain}/.well-known/nostr.json?name={urllib.parse.quote(local)}"
+    req = urllib.request.Request(url, headers=UA)
+    with urllib.request.urlopen(req, timeout=15) as r:
+        doc = json.load(r)
+    pk = (doc.get("names") or {}).get(local)
+    if not pk:
+        raise ValueError(f"NIP-05 '{addr}' has no entry for name '{local}'")
+    return pk.lower()
+
+def nprofile_pubkey(s):
+    _, data = bech32_decode(s)
+    tlv = bytes(convertbits(data, 5, 8, False))
+    i = 0
+    while i + 2 <= len(tlv):
+        t, ln = tlv[i], tlv[i + 1]
+        val = tlv[i + 2:i + 2 + ln]
+        if t == 0 and ln == 32:                      # TLV type 0 = special (pubkey)
+            return val.hex()
+        i += 2 + ln
+    raise ValueError("nprofile contains no pubkey TLV")
+
+def to_pubkey(identity):
+    s = identity.strip()
+    if s.startswith("npub1"):
+        _, data = bech32_decode(s)
+        return ("npub", bytes(convertbits(data, 5, 8, False)).hex())
+    if s.startswith("nprofile1"):
+        return ("nprofile", nprofile_pubkey(s))
+    low = s.lower()
+    if len(low) == 64 and all(c in "0123456789abcdef" for c in low):
+        return ("hex", low)
+    if "." in s:                                     # looks like a NIP-05 domain/address
+        return ("nip05", resolve_nip05(s))
+    raise ValueError(f"unrecognized identity: {identity!r}")
+
+# ---------- key -> bitcoin addresses ----------
+SECP_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+
+def _lift_y(x, want_odd):
+    """Recover Y for an x-only key. secp256k1 p ≡ 3 (mod 4) → sqrt = a^((p+1)/4)."""
+    a = (pow(x, 3, SECP_P) + 7) % SECP_P
+    y = pow(a, (SECP_P + 1) // 4, SECP_P)
+    if (y * y - a) % SECP_P != 0:
+        return None                       # x is not a valid curve point
+    return SECP_P - y if (y & 1) != want_odd else y
+
+# --- minimal secp256k1 for the BIP341 taproot tweak ---
+SECP_G = (0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798,
+          0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8)
+
+def _inv(a):
+    return pow(a, SECP_P - 2, SECP_P)
+
+def _pt_add(P, Q):
+    if P is None: return Q
+    if Q is None: return P
+    x1, y1 = P; x2, y2 = Q
+    if x1 == x2 and (y1 + y2) % SECP_P == 0:
+        return None                                   # point at infinity
+    m = ((3 * x1 * x1) * _inv(2 * y1) if P == Q
+         else (y2 - y1) * _inv(x2 - x1)) % SECP_P
+    x3 = (m * m - x1 - x2) % SECP_P
+    return (x3, (m * (x1 - x3) - y1) % SECP_P)
+
+def _scalar_mult(k, P):
+    R = None
+    while k:
+        if k & 1:
+            R = _pt_add(R, P)
+        P = _pt_add(P, P)
+        k >>= 1
+    return R
+
+def _tagged_hash(tag, msg):
+    th = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(th + th + msg).digest()
+
+def _lift_x_even(x):
+    """BIP340 lift_x: the unique point with this X and even Y."""
+    a = (pow(x, 3, SECP_P) + 7) % SECP_P
+    y = pow(a, (SECP_P + 1) // 4, SECP_P)
+    if (y * y - a) % SECP_P != 0:
+        return None
+    return (x, SECP_P - y if (y & 1) else y)
+
+def p2tr_keypath(xonly):
+    """Canonical BIP341 key-path output key: Q = P + tagged('TapTweak',P)*G."""
+    P = _lift_x_even(int.from_bytes(xonly, "big"))
+    if P is None:
+        return None
+    t = int.from_bytes(_tagged_hash("TapTweak", xonly), "big")
+    Q = _pt_add(P, _scalar_mult(t, SECP_G))
+    return Q[0].to_bytes(32, "big")
+
+def derive_addresses(xonly_hex):
+    xonly = bytes.fromhex(xonly_hex)
+    if len(xonly) != 32:
+        raise ValueError("pubkey is not 32 bytes (x-only)")
+    x = int.from_bytes(xonly, "big")
+    out = []
+    # Bitcoin's Y-parity for this x-only key is unknown, so each hash160-based
+    # type has TWO candidates (0x02 / 0x03 compressed forms) — check both.
+    for prefix, tag in ((b"\x02", "02"), (b"\x03", "03")):
+        h160 = hash160(prefix + xonly)
+        out.append((f"P2PKH-{tag}",  b58check(b"\x00" + h160)))
+        out.append((f"P2WPKH-{tag}", segwit_addr("bc", 0, h160)))
+        redeem = hash160(b"\x00\x14" + h160)          # BIP141 P2WPKH redeemscript
+        out.append((f"P2SH-{tag}",   b58check(b"\x05" + redeem)))
+    # uncompressed legacy P2PKH (recover full point; both Y parities)
+    for want_odd, tag in ((0, "Uev"), (1, "Uod")):
+        y = _lift_y(x, want_odd)
+        if y is not None:
+            unc = b"\x04" + xonly + y.to_bytes(32, "big")
+            out.append((f"P2PKH-{tag}", b58check(b"\x00" + hash160(unc))))
+    # Canonical Taproot (BIP341 key-path): the address encodes the *tweaked*
+    # output key Q = P + TapTweak(P)*G, not the raw internal key. This is what
+    # real wallets and the OPENETR reference app use.
+    qx = p2tr_keypath(xonly)
+    if qx is not None:
+        out.append(("P2TR", segwit_addr("bc", 1, qx)))
+    out.append(("P2TR-raw", segwit_addr("bc", 1, xonly)))   # untweaked (naive)
+    return out
+
+# ---------- balances + history (Esplora) ----------
+EXPLORER_WEB = EXPLORER.rsplit("/api", 1)[0]          # https://mempool.space
+
+def _get_json(url):
+    req = urllib.request.Request(url, headers=UA)
+    with urllib.request.urlopen(req, timeout=25) as r:
+        return json.load(r)
+
+def addr_url(addr):
+    return f"{EXPLORER_WEB}/address/{addr}"
+
+def tx_url(txid):
+    return f"{EXPLORER_WEB}/tx/{txid}"
+
+def address_balance(addr):
+    """Return (confirmed_sats, unconfirmed_sats, tx_count) from Esplora."""
+    d = _get_json(f"{EXPLORER}/address/{addr}")
+    c, m = d["chain_stats"], d["mempool_stats"]
+    confirmed = c["funded_txo_sum"] - c["spent_txo_sum"]
+    unconfirmed = m["funded_txo_sum"] - m["spent_txo_sum"]
+    return confirmed, unconfirmed, c["tx_count"] + m["tx_count"]
+
+def address_txs(addr, max_txs=5000):
+    """All txs for addr (confirmed oldest->newest, then mempool/pending)."""
+    mp = _get_json(f"{EXPLORER}/address/{addr}/txs/mempool")
+    conf, last = [], None
+    while len(conf) < max_txs:
+        url = f"{EXPLORER}/address/{addr}/txs/chain"
+        if last:
+            url += f"/{last}"
+        batch = _get_json(url)
+        if not batch:
+            break
+        conf.extend(batch)
+        last = batch[-1]["txid"]
+        if len(batch) < 25:
+            break
+        time.sleep(0.3)
+    conf.reverse()                                    # oldest -> newest
+    return conf + list(reversed(mp))                  # pending last
+
+def tx_delta(tx, addr):
+    """Net sats effect of `tx` on `addr` (received in vout minus spent in vin)."""
+    got = sum(v.get("value", 0) for v in tx.get("vout", [])
+              if v.get("scriptpubkey_address") == addr)
+    spent = sum(i.get("prevout", {}).get("value", 0) for i in tx.get("vin", [])
+                if i.get("prevout", {}).get("scriptpubkey_address") == addr)
+    return got - spent
+
+def build_ledger(addr):
+    """Full per-address ledger with a running balance and explorer links."""
+    led, run = [], 0
+    for t in address_txs(addr):
+        d = tx_delta(t, addr)
+        run += d
+        st = t.get("status", {})
+        led.append({
+            "txid": t["txid"], "tx_url": tx_url(t["txid"]),
+            "confirmed": st.get("confirmed", False),
+            "height": st.get("block_height"),
+            "time": st.get("block_time"),
+            "delta_sats": d, "running_sats": run,
+        })
+    return led
+
+def sats_str(s):
+    return f"{s:,} sats ({s/1e8:.8f} BTC)"
+
+def _date(ts):
+    return time.strftime("%Y-%m-%d", time.gmtime(ts)) if ts else "pending   "
+
+# ---------- per-identity report ----------
+def process(identity, history=False):
+    kind, pk = to_pubkey(identity)
+    npub = bech32_encode("npub", convertbits(bytes.fromhex(pk), 8, 5), "bech32")
+    result = {"input": identity, "resolved_via": kind, "pubkey": pk,
+              "npub": npub, "addresses": [], "total_sats": 0}
+    for label, addr in derive_addresses(pk):
+        entry = {"type": label, "address": addr, "address_url": addr_url(addr)}
+        try:
+            conf, unconf, txc = address_balance(addr)
+            entry.update(confirmed_sats=conf, unconfirmed_sats=unconf, tx_count=txc)
+            result["total_sats"] += conf + unconf
+            if history and txc:                      # only walk addresses with activity
+                try:
+                    entry["history"] = build_ledger(addr)
+                except Exception as e:
+                    entry["history_error"] = str(e)
+                time.sleep(0.4)
+        except Exception as e:                       # network/rate-limit: degrade gracefully
+            entry["error"] = str(e)
+        result["addresses"].append(entry)
+        time.sleep(0.6)                              # be polite to the public API
+    return result
+
+def print_human(res):
+    flag = "  ⚠ FUNDED" if res["total_sats"] > 0 else ""
+    print(f"\n{res['input']}  (via {res['resolved_via']}){flag}")
+    print(f"  pubkey : {res['pubkey']}")
+    print(f"  npub   : {res['npub']}")
+    for a in res["addresses"]:
+        if "error" in a:
+            print(f"  {a['type']:<10} {a['address']:<46} balance: ?  ({a['error']})")
+            continue
+        bal = a["confirmed_sats"] + a["unconfirmed_sats"]
+        mark = "  ⚠" if bal > 0 else ""
+        unc = f" (+{a['unconfirmed_sats']} unconf)" if a["unconfirmed_sats"] else ""
+        print(f"  {a['type']:<10} {a['address']:<46} "
+              f"balance: {a['confirmed_sats']:,} sats{unc}  ({a['tx_count']} tx){mark}")
+        if a.get("tx_count"):
+            print(f"             ↳ {a['address_url']}")
+        if "history_error" in a:
+            print(f"             history unavailable: {a['history_error']}")
+        for h in a.get("history", []):
+            sign = "+" if h["delta_sats"] >= 0 else "−"
+            tag = "" if h["confirmed"] else "  (pending)"
+            print(f"             {_date(h['time'])}  {sign}{abs(h['delta_sats']):>12,}"
+                  f"  bal {h['running_sats']:>13,}{tag}  {h['tx_url']}")
+    print(f"  TOTAL  : {sats_str(res['total_sats'])}"
+          f"{'  ⚠ KEY HOLDS FUNDS' if res['total_sats'] else ''}")
+
+# ---------- self-test (offline; BIP173 generator-point vectors) ----------
+def selftest():
+    x = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    addrs = dict(derive_addresses(x))
+    # BIP341 key-path vector from the OPENETR reference app (alex@gleasonator.com)
+    ik = "0461fcbecc4c3374439932d6b8f11269ccdb7cc973ad7a50ae362db135a474dd"
+    tk = _tagged_hash("TapTweak", bytes.fromhex(ik)).hex()
+    tv = dict(derive_addresses(ik))
+    checks = {
+        "P2PKH-02":  ("1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH", addrs["P2PKH-02"]),
+        "P2WPKH-02": ("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", addrs["P2WPKH-02"]),
+        "TapTweak":  ("1619853a7b2e50b0e759137fbf7378e67883c9a43d63f6e32f6633e54b8cadd7", tk),
+        "P2TR(341)": ("bc1pvdaezs0mdhxgrfhw2zjsw4r02wlzrafd7stxcvpzzscsh8hv6vhqdc9ets", tv["P2TR"]),
+    }
+    ok = True
+    for name, (want, got) in checks.items():
+        good = want == got
+        ok &= good
+        print(f"  {'PASS' if good else 'FAIL'} {name}: {got}"
+              f"{'' if good else '  expected ' + want}")
+    print(f"  info P2TR-raw(untweaked): {addrs['P2TR-raw']}")
+    print("selftest:", "OK" if ok else "FAILED")
+    sys.exit(0 if ok else 1)
+
+def main(argv):
+    as_json = history = False
+    while argv and argv[0].startswith("-"):
+        flag, argv = argv[0], argv[1:]
+        if flag in ("-h", "--help"):
+            print(__doc__); return 0
+        elif flag == "--selftest":
+            selftest()
+        elif flag == "--json":
+            as_json = True
+        elif flag == "--history":
+            history = True
+        else:
+            print(f"error: unknown flag {flag}", file=sys.stderr); return 2
+    if not argv:
+        print("error: no identity given", file=sys.stderr)
+        return 2
+    out, rc = [], 0
+    for ident in argv:
+        try:
+            res = process(ident, history=history)
+            out.append(res)
+            if not as_json:
+                print_human(res)
+        except Exception as e:
+            rc = 1
+            if as_json:
+                out.append({"input": ident, "error": str(e)})
+            else:
+                print(f"\n{ident}\n  error: {e}", file=sys.stderr)
+    if as_json:
+        print(json.dumps(out, indent=2))
+    return rc
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/lib/keyExposureService.ts
+++ b/lib/keyExposureService.ts
@@ -1,0 +1,392 @@
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+import { ripemd160 } from "@noble/hashes/ripemd160";
+import { bech32, bech32m } from "bech32";
+import { nip19 } from "nostr-tools";
+
+export const DEFAULT_ESPLORA_ENDPOINT = "https://mempool.space/api";
+
+// ---------- Types ----------
+
+export interface LedgerEntry {
+  txid: string;
+  txUrl: string;
+  confirmed: boolean;
+  height: number | null;
+  time: number | null;
+  deltaSats: number;
+  runningSats: number;
+}
+
+export interface AddressReport {
+  type: string;
+  address: string;
+  addressUrl: string;
+  confirmedSats: number;
+  unconfirmedSats: number;
+  txCount: number;
+  history?: LedgerEntry[];
+  error?: string;
+}
+
+export interface ExposureReport {
+  input: string;
+  resolvedVia: string;
+  pubkeyHex: string;
+  npub: string;
+  addresses: AddressReport[];
+  totalSats: number;
+  source: string;
+  fetchedAt: number;
+}
+
+interface AddressInfo {
+  type: string;
+  address: string;
+  primary?: boolean;
+}
+
+// ---------- Crypto utilities ----------
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function taggedHash(tag: string, msg: Uint8Array): Uint8Array {
+  const tagHash = sha256(new TextEncoder().encode(tag));
+  const input = new Uint8Array(tagHash.length * 2 + msg.length);
+  input.set(tagHash, 0);
+  input.set(tagHash, tagHash.length);
+  input.set(msg, tagHash.length * 2);
+  return sha256(input);
+}
+
+function hash160(bytes: Uint8Array): Uint8Array {
+  return ripemd160(sha256(bytes));
+}
+
+function sha256d(bytes: Uint8Array): Uint8Array {
+  return sha256(sha256(bytes));
+}
+
+function base58Encode(bytes: Uint8Array): string {
+  const ALPHABET =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  let n = BigInt("0x" + toHex(bytes));
+  const BIGINT_58 = BigInt(58);
+  const BIGINT_0 = BigInt(0);
+  let s = "";
+  while (n > BIGINT_0) {
+    const r = Number(n % BIGINT_58);
+    n = n / BIGINT_58;
+    s = ALPHABET[r] + s;
+  }
+  let zeros = 0;
+  for (const b of bytes) {
+    if (b !== 0) break;
+    zeros++;
+  }
+  return "1".repeat(zeros) + s;
+}
+
+function base58Check(payload: Uint8Array): string {
+  const checksum = sha256d(payload).slice(0, 4);
+  const full = new Uint8Array(payload.length + 4);
+  full.set(payload);
+  full.set(checksum, payload.length);
+  return base58Encode(full);
+}
+
+// ---------- Address derivation ----------
+
+function p2pkhAddress(h160: Uint8Array): string {
+  const payload = new Uint8Array(21);
+  payload[0] = 0x00;
+  payload.set(h160, 1);
+  return base58Check(payload);
+}
+
+function p2shAddress(h160: Uint8Array): string {
+  const payload = new Uint8Array(21);
+  payload[0] = 0x05;
+  payload.set(h160, 1);
+  return base58Check(payload);
+}
+
+function p2wpkhAddress(h160: Uint8Array): string {
+  const words = bech32.toWords(h160 as unknown as Buffer);
+  return bech32.encode("bc", [0, ...words]);
+}
+
+function p2trAddress(xonly: Uint8Array): string {
+  const words = bech32m.toWords(xonly as unknown as Buffer);
+  return bech32m.encode("bc", [1, ...words]);
+}
+
+// BIP341 key-path tweak: Q = P + TapTweak(P) * G
+function p2trKeyPath(xonlyHex: string): Uint8Array | null {
+  try {
+    const xonlyBytes = fromHex(xonlyHex);
+    const P = secp256k1.ProjectivePoint.fromHex("02" + xonlyHex);
+    const tweak = taggedHash("TapTweak", xonlyBytes);
+    const t = BigInt("0x" + toHex(tweak)) % secp256k1.CURVE.n;
+    const Q = P.add(secp256k1.ProjectivePoint.BASE.multiply(t));
+    return Q.toRawBytes(true).slice(1);
+  } catch {
+    return null;
+  }
+}
+
+export function deriveAddresses(xonlyHex: string): AddressInfo[] {
+  const xonly = fromHex(xonlyHex);
+  const out: AddressInfo[] = [];
+
+  // Hash160-based types: two Y-parity candidates (02 / 03)
+  for (const [prefix, tag] of [
+    [0x02, "02"],
+    [0x03, "03"],
+  ] as const) {
+    const compressed = new Uint8Array(33);
+    compressed[0] = prefix;
+    compressed.set(xonly, 1);
+    const h160 = hash160(compressed);
+
+    out.push({ type: `P2PKH-${tag}`, address: p2pkhAddress(h160) });
+    out.push({ type: `P2WPKH-${tag}`, address: p2wpkhAddress(h160) });
+
+    // P2SH-P2WPKH: hash160 of the redeemScript (OP_0 <20-byte-hash>)
+    const redeemScript = new Uint8Array(22);
+    redeemScript[0] = 0x00;
+    redeemScript[1] = 0x14;
+    redeemScript.set(h160, 2);
+    out.push({
+      type: `P2SH-${tag}`,
+      address: p2shAddress(hash160(redeemScript)),
+    });
+  }
+
+  // Canonical BIP341 Taproot (tweaked output key) — the one real wallets use
+  const qx = p2trKeyPath(xonlyHex);
+  if (qx) {
+    out.push({ type: "P2TR", address: p2trAddress(qx), primary: true });
+  }
+
+  // Untweaked P2TR (naive mapping of raw key — usually empty)
+  out.push({ type: "P2TR-raw", address: p2trAddress(xonly) });
+
+  return out;
+}
+
+// ---------- Identity resolution ----------
+
+export async function resolveIdentity(
+  identity: string
+): Promise<{ hex: string; resolvedVia: string }> {
+  const s = identity.trim();
+
+  if (/^[0-9a-fA-F]{64}$/.test(s)) {
+    return { hex: s.toLowerCase(), resolvedVia: "hex" };
+  }
+
+  if (s.startsWith("npub1") || s.startsWith("nprofile1")) {
+    const decoded = nip19.decode(s);
+    if (decoded.type === "npub") {
+      return { hex: decoded.data, resolvedVia: "npub" };
+    }
+    if (decoded.type === "nprofile") {
+      return { hex: decoded.data.pubkey, resolvedVia: "nprofile" };
+    }
+    throw new Error("Unrecognized bech32 type");
+  }
+
+  if (s.includes(".")) {
+    return resolveNip05(s);
+  }
+
+  throw new Error(
+    "Unrecognized identity — use npub, nprofile, NIP-05, or 64-char hex"
+  );
+}
+
+async function resolveNip05(
+  identity: string
+): Promise<{ hex: string; resolvedVia: string }> {
+  const [local, domain] = identity.includes("@")
+    ? identity.split("@", 2)
+    : ["_", identity];
+  const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(local)}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`NIP-05 fetch failed: ${res.status}`);
+  const doc = await res.json();
+  const pk = doc?.names?.[local];
+  if (!pk) throw new Error(`NIP-05: no entry for '${local}' at ${domain}`);
+  return { hex: (pk as string).toLowerCase(), resolvedVia: "nip05" };
+}
+
+// ---------- Esplora client ----------
+
+function explorerWebBase(endpoint: string): string {
+  return endpoint.replace(/\/api\/?$/, "");
+}
+
+async function esploraGet<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+interface EsploraAddressStats {
+  funded_txo_sum: number;
+  spent_txo_sum: number;
+  tx_count: number;
+}
+
+interface EsploraAddress {
+  chain_stats: EsploraAddressStats;
+  mempool_stats: EsploraAddressStats;
+}
+
+async function fetchAddressStats(
+  addr: string,
+  endpoint: string
+): Promise<{ confirmedSats: number; unconfirmedSats: number; txCount: number }> {
+  const data = await esploraGet<EsploraAddress>(`${endpoint}/address/${addr}`);
+  return {
+    confirmedSats:
+      data.chain_stats.funded_txo_sum - data.chain_stats.spent_txo_sum,
+    unconfirmedSats:
+      data.mempool_stats.funded_txo_sum - data.mempool_stats.spent_txo_sum,
+    txCount: data.chain_stats.tx_count + data.mempool_stats.tx_count,
+  };
+}
+
+interface EsploraVout {
+  value: number;
+  scriptpubkey_address?: string;
+}
+
+interface EsploraVin {
+  prevout?: { value: number; scriptpubkey_address?: string };
+}
+
+interface EsploraTransaction {
+  txid: string;
+  vout: EsploraVout[];
+  vin: EsploraVin[];
+  status: { confirmed: boolean; block_height?: number; block_time?: number };
+}
+
+function txDelta(tx: EsploraTransaction, addr: string): number {
+  const received = tx.vout
+    .filter((v) => v.scriptpubkey_address === addr)
+    .reduce((s, v) => s + v.value, 0);
+  const spent = tx.vin
+    .filter((i) => i.prevout?.scriptpubkey_address === addr)
+    .reduce((s, i) => s + (i.prevout?.value ?? 0), 0);
+  return received - spent;
+}
+
+export async function fetchAddressHistory(
+  addr: string,
+  endpoint = DEFAULT_ESPLORA_ENDPOINT,
+  maxTxs = 2000
+): Promise<LedgerEntry[]> {
+  const web = explorerWebBase(endpoint);
+
+  // Paginated confirmed txs (API returns 25 newest-first per page)
+  const confirmed: EsploraTransaction[] = [];
+  let lastTxid: string | null = null;
+  while (confirmed.length < maxTxs) {
+    const url: string = lastTxid
+      ? `${endpoint}/address/${addr}/txs/chain/${lastTxid}`
+      : `${endpoint}/address/${addr}/txs/chain`;
+    const batch: EsploraTransaction[] = await esploraGet<EsploraTransaction[]>(url);
+    if (!batch.length) break;
+    confirmed.push(...batch);
+    lastTxid = batch[batch.length - 1].txid;
+    if (batch.length < 25) break;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  confirmed.reverse(); // oldest → newest
+
+  const mempool = await esploraGet<EsploraTransaction[]>(
+    `${endpoint}/address/${addr}/txs/mempool`
+  );
+
+  let running = 0;
+  return [...confirmed, ...mempool].map((tx) => {
+    const delta = txDelta(tx, addr);
+    running += delta;
+    return {
+      txid: tx.txid,
+      txUrl: `${web}/tx/${tx.txid}`,
+      confirmed: tx.status?.confirmed ?? false,
+      height: tx.status?.block_height ?? null,
+      time: tx.status?.block_time ?? null,
+      deltaSats: delta,
+      runningSats: running,
+    };
+  });
+}
+
+// ---------- Main entry point ----------
+
+export async function getExposure(
+  identity: string,
+  endpoint = DEFAULT_ESPLORA_ENDPOINT,
+  onProgress?: (phase: string, current: number, total: number) => void
+): Promise<ExposureReport> {
+  const { hex: pubkeyHex, resolvedVia } = await resolveIdentity(identity);
+  const npub = nip19.npubEncode(pubkeyHex);
+  const addresses = deriveAddresses(pubkeyHex);
+  const web = explorerWebBase(endpoint);
+
+  const reports: AddressReport[] = [];
+  let totalSats = 0;
+
+  for (let i = 0; i < addresses.length; i++) {
+    const { type, address } = addresses[i];
+    onProgress?.(type, i + 1, addresses.length);
+
+    const addressUrl = `${web}/address/${address}`;
+    try {
+      const stats = await fetchAddressStats(address, endpoint);
+      totalSats += stats.confirmedSats + stats.unconfirmedSats;
+      reports.push({ type, address, addressUrl, ...stats });
+    } catch (e) {
+      reports.push({
+        type,
+        address,
+        addressUrl,
+        confirmedSats: 0,
+        unconfirmedSats: 0,
+        txCount: 0,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    // Be polite to the public API
+    await new Promise((r) => setTimeout(r, 600));
+  }
+
+  return {
+    input: identity,
+    resolvedVia,
+    pubkeyHex,
+    npub,
+    addresses: reports,
+    totalSats,
+    source: web,
+    fetchedAt: Date.now(),
+  };
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -56,7 +56,8 @@ interface AppState {
     | "decimator"
     | "noteNuke"
     | "snoopable"
-    | "clonable";
+    | "clonable"
+    | "muggable";
   showAuthModal: boolean;
   hasCompletedOnboarding: boolean;
 
@@ -94,7 +95,8 @@ interface AppState {
       | "decimator"
       | "noteNuke"
       | "snoopable"
-      | "clonable",
+      | "clonable"
+      | "muggable",
   ) => void;
   setShowAuthModal: (show: boolean) => void;
   setHasCompletedOnboarding: (completed: boolean) => void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutable",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/keyExposure.test.ts
+++ b/tests/keyExposure.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { deriveAddresses } from "@/lib/keyExposureService";
+
+// Helper: index addresses by type
+function byType(xonlyHex: string): Record<string, string> {
+  return Object.fromEntries(
+    deriveAddresses(xonlyHex).map((a) => [a.type, a.address])
+  );
+}
+
+describe("deriveAddresses — BIP173 generator-point vectors", () => {
+  // secp256k1 generator point G (x-only)
+  const G =
+    "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+  it("P2PKH-02", () => {
+    expect(byType(G)["P2PKH-02"]).toBe("1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH");
+  });
+
+  it("P2WPKH-02", () => {
+    expect(byType(G)["P2WPKH-02"]).toBe(
+      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+    );
+  });
+});
+
+describe("deriveAddresses — OPENETR BIP341 Taproot vector", () => {
+  // alex@gleasonator.com internal key (used by the OPENETR reference app)
+  const OPENETR_KEY =
+    "0461fcbecc4c3374439932d6b8f11269ccdb7cc973ad7a50ae362db135a474dd";
+
+  it("canonical P2TR (tweaked key-path)", () => {
+    expect(byType(OPENETR_KEY)["P2TR"]).toBe(
+      "bc1pvdaezs0mdhxgrfhw2zjsw4r02wlzrafd7stxcvpzzscsh8hv6vhqdc9ets"
+    );
+  });
+});
+
+describe("deriveAddresses — output shape", () => {
+  const G =
+    "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+  it("returns all expected address types", () => {
+    const types = deriveAddresses(G).map((a) => a.type);
+    expect(types).toContain("P2PKH-02");
+    expect(types).toContain("P2PKH-03");
+    expect(types).toContain("P2WPKH-02");
+    expect(types).toContain("P2WPKH-03");
+    expect(types).toContain("P2SH-02");
+    expect(types).toContain("P2SH-03");
+    expect(types).toContain("P2TR");
+    expect(types).toContain("P2TR-raw");
+  });
+
+  it("marks P2TR as primary", () => {
+    const primary = deriveAddresses(G).find((a) => a.primary);
+    expect(primary?.type).toBe("P2TR");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **Muggable**, a new tool under Other Stuff that checks whether a Nostr identity controls Bitcoin on-chain
- A Nostr public key is a secp256k1 key — the same curve Bitcoin uses — so any npub has derivable Bitcoin addresses that can hold real funds
- Bumps Mutable to **v1.4.0**

## What changed

### Core service (`lib/keyExposureService.ts`)
- `deriveAddresses(xonlyHex)` — derives all address types from an x-only pubkey: canonical BIP341 Taproot (P2TR, tweaked key-path), P2PKH/P2WPKH/P2SH-P2WPKH for both Y-parities, and untweaked P2TR-raw
- BIP341 tweak uses `@noble/curves/secp256k1` point math + tagged SHA-256 hash
- `resolveIdentity()` — handles npub, nprofile, 64-char hex, NIP-05
- `getExposure()` — resolves identity, queries all addresses against Esplora, returns `ExposureReport` with per-address balances and progress callback
- `fetchAddressHistory()` — paginates full confirmed history + mempool, builds running-balance ledger

### Tests (`tests/keyExposure.test.ts`)
- BIP173 generator-point vectors: P2PKH-02, P2WPKH-02
- OPENETR BIP341 Taproot vector: canonical P2TR for `alex@gleasonator.com` internal key
- All 5 tests pass

### UI (`components/Muggable.tsx`, `MuggableWrapper.tsx`, `app/muggable/page.tsx`)
- Profile name search with debounced relay lookup and dropdown (same pattern as Snoopable)
- Signed-in users get a **Check me** button that auto-runs
- Progress bar while querying addresses (600ms polite delay per address)
- Summary box shows profile avatar + display name + NIP-05 — green when funded, blue when clean
- Primary P2TR address highlighted; secondary addresses collapsed by default
- Per-address lazy-load history: full date/delta/running-balance ledger with per-tx explorer links
- Collapsible **sweep guide** (yellow, appears only when funds detected): Sparrow Wallet steps, nsec→WIF conversion notes, safety warning
- Configurable Esplora endpoint in advanced options with privacy note
- Warning section explains why on-chain zaps are a privacy trap; Lightning recommendation

### Navigation
- Muggable added to Other Stuff dropdown (desktop + mobile) in `DashboardNav` and `dashboard/page.tsx`
- `lib/store.ts` activeTab type updated

## Test plan
- [ ] `npx vitest run tests/keyExposure.test.ts` — all 5 pass
- [ ] `npx tsc --noEmit` — no errors
- [ ] Visit `/muggable` — page loads, warning copy visible
- [ ] Enter an npub with known on-chain history — green funded box appears with avatar
- [ ] Enter an npub with no on-chain history — blue clean box appears
- [ ] Expand history on a funded address — ledger loads with running balance
- [ ] Expand sweep guide — all steps visible, nsec warning shown
- [ ] Check me button (signed in) — auto-runs check for own key
- [ ] Name search — dropdown appears, selecting a profile auto-runs check
- [ ] Other Stuff menu — Muggable appears on desktop and mobile