### PR TITLE
fix(auth): defer relay-storage sync to dashboard mount

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -42,6 +42,7 @@ import Footer from "@/components/Footer";
 import { Profile } from "@/types";
 import { fetchProfile, getFollowListPubkeys } from "@/lib/nostr";
 import { backupService } from "@/lib/backupService";
+import { syncManager } from "@/lib/syncManager";
 
 function DashboardContent() {
   const router = useRouter();
@@ -56,6 +57,7 @@ function DashboardContent() {
     muteList,
     userProfile,
     setUserProfile,
+    signer,
   } = useStore();
   const [selectedProfile, setSelectedProfile] = useState<Profile | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
@@ -151,6 +153,20 @@ function DashboardContent() {
 
     loadUserProfile();
   }, [session, userProfile, setUserProfile]);
+
+  // Sync app data with relays once per tab+pubkey, after signer is ready.
+  // Deferred from sign-in so the four service decrypts don't pile up as
+  // simultaneous extension/bunker permission prompts during login.
+  useEffect(() => {
+    if (!session?.pubkey || !signer) return;
+    const key = `mutable-synced-${session.pubkey}`;
+    if (sessionStorage.getItem(key)) return;
+    sessionStorage.setItem(key, "1");
+    syncManager.syncAll(session.pubkey, session.relays).catch((error) => {
+      console.error("Failed to sync app data with relays:", error);
+      sessionStorage.removeItem(key);
+    });
+  }, [session?.pubkey, session?.relays, signer]);
 
   // Refresh mute list when tab becomes visible (but only if no unsaved changes)
   useEffect(() => {

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -10,7 +10,6 @@ import {
   getBestRelayList,
 } from "@/lib/nostr";
 import { Nip07Signer, Nip46Signer } from "@/lib/signers";
-import { syncManager } from "@/lib/syncManager";
 import { UserSession } from "@/types";
 
 // Store for active nostrconnect sessions (used for cleanup)
@@ -84,11 +83,6 @@ export function useAuth() {
       // Fetch user's mute list
       await loadMuteList(pubkey, relays);
 
-      // Sync all app data with relay storage
-      syncManager.syncAll(pubkey, relays).catch((error) => {
-        console.error("Failed to sync app data with relays:", error);
-      });
-
       return newSession;
     } catch (error) {
       setAuthState("error");
@@ -153,11 +147,6 @@ export function useAuth() {
 
         // Fetch user's mute list
         await loadMuteList(pubkey, relays);
-
-        // Sync all app data with relay storage
-        syncManager.syncAll(pubkey, relays).catch((error) => {
-          console.error("Failed to sync app data with relays:", error);
-        });
 
         return newSession;
       } catch (error) {
@@ -255,11 +244,6 @@ export function useAuth() {
 
         // Fetch user's mute list
         await loadMuteList(pubkey, relays);
-
-        // Sync all app data with relay storage
-        syncManager.syncAll(pubkey, relays).catch((error) => {
-          console.error("Failed to sync app data with relays:", error);
-        });
 
         return newSession;
       } catch (error) {
@@ -384,11 +368,6 @@ export function useAuth() {
       restoreSigner().then(() => {
         // Refresh mute list to ensure we have latest data from relays
         loadMuteList(session.pubkey, session.relays);
-
-        // Sync all app data with relay storage
-        syncManager.syncAll(session.pubkey, session.relays).catch((error) => {
-          console.error("Failed to sync app data with relays:", error);
-        });
       });
     }
   }, [session, authState, setAuthState, loadMuteList, restoreSigner]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutable",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Removes the four parallel `syncManager.syncAll()` calls from `hooks/useAuth.ts` (NIP-07 sign-in, NIP-46 sign-in, NIP-46 QR sign-in, and silent restore).
- Adds a single deferred sync in `app/dashboard/page.tsx`, gated by a `sessionStorage` flag (`mutable-synced-<pubkey>`) and a non-null `signer`, so it runs once per tab per user — and only after the signer is actually ready.
- Bumps version to `1.4.1`.

## Why

On every sign-in path we used to fire `syncManager.syncAll()` immediately after `setSession`. That decrypts four kind-30078 events (Protected Users, Blacklist, Preferences, Imported Packs) in parallel, and each `nip04_decrypt` / `nip44_decrypt` is its own NIP-07 prompt — or, with NIP-46, a separate row in the bunker's permissions-review screen. A user reported ~4 simultaneous popups the moment the auth modal closed; the bunker flow showed an even noisier pile-up because the `ping()` we send on session restore got tacked on.

Same data, same decrypts. They just no longer land at the worst possible moment (the modal-close transition).

## Tradeoff

The sync now happens on dashboard mount instead of immediately at sign-in. A user who signs in and navigates away from `/dashboard` before mount completes wouldn't trigger a sync — but every sign-in path currently routes through the dashboard, and the flag is keyed by pubkey so a fresh tab always re-syncs. On failure the flag is cleared so the next mount retries.

## Test plan

- [ ] Sign in with NIP-07 (Alby/nos2x) — confirm only `get_public_key` and the mute-list decrypt prompt during sign-in; subsequent decrypts arrive after the dashboard renders.
- [ ] Sign in with NIP-46 bunker URL (Amber) — confirm the bunker's permissions-review screen no longer shows piled-up `ping/pong` entries; activity log shows `connect → get_public_key → nip44_decrypt` cleanly.
- [ ] Sign in with NIP-46 nostrconnect QR — same expectation as bunker.
- [ ] Reload the dashboard tab while logged in — should not re-trigger sync (`sessionStorage` guard).
- [ ] Open a new tab while logged in — should re-sync once (per-tab `sessionStorage`).
- [ ] Disconnect and reconnect as same user — local data should still be valid; force-resync via Settings if needed.
- [ ] Disconnect and reconnect as a different user — should sync (different pubkey key).