### PR TITLE
feat(decimator): add Unfollow Everyone + /decimator route (v1.6.1)

### DIFF
--- a/app/decimator/page.tsx
+++ b/app/decimator/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from "react";
+import { Metadata } from "next";
+import DecimatorWrapper from "@/components/DecimatorWrapper";
+
+export const metadata: Metadata = {
+  title: "Decimator by Mutable: Trim your Nostr follow list",
+  description:
+    "Trim your follow list. Randomly remove a percentage, shrink to a target count, or unfollow everyone — with a local backup saved before any change.",
+  openGraph: {
+    title: "Decimator by Mutable: Trim your Nostr follow list",
+    description:
+      "Trim your follow list. Randomly remove a percentage, shrink to a target count, or unfollow everyone — with a local backup saved before any change.",
+  },
+  twitter: {
+    card: "summary",
+    title: "Decimator by Mutable: Trim your Nostr follow list",
+    description:
+      "Trim your follow list. Randomly remove a percentage, shrink to a target count, or unfollow everyone — with a local backup saved before any change.",
+  },
+};
+
+export default function DecimatorPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800" />
+      }
+    >
+      <DecimatorWrapper />
+    </Suspense>
+  );
+}

--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -66,7 +66,7 @@ const pageUrls: Record<ActivePage, string> = {
   noteNuke: "/note-nuke",
   domainPurge: "/dashboard?tab=domainPurge",
   purgatory: "/purgatory",
-  decimator: "/dashboard?tab=decimator",
+  decimator: "/decimator",
   listCleaner: "/dashboard?tab=listCleaner",
   snoopable: "/snoopable",
   clonable: "/clonable",

--- a/components/Decimator.tsx
+++ b/components/Decimator.tsx
@@ -269,6 +269,78 @@ export default function Decimator() {
     setShowShareModal(true);
   };
 
+  const handleUnfollowEveryone = async () => {
+    if (!session) return;
+
+    setError(null);
+
+    // Fetch the current follow list up front so the confirm dialog can show
+    // the exact count and so we have something to back up.
+    let currentFollows: string[];
+    try {
+      setProcessing(true);
+      setProgress("Fetching your current follow list…");
+      currentFollows = await getFollowListPubkeys(
+        session.pubkey,
+        session.relays,
+      );
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch follow list"));
+      setProcessing(false);
+      setProgress("");
+      return;
+    } finally {
+      setProgress("");
+    }
+
+    if (currentFollows.length === 0) {
+      setProcessing(false);
+      setError("You are not following anyone — nothing to unfollow.");
+      return;
+    }
+
+    const confirmed = confirm(
+      `⚠️ UNFOLLOW EVERYONE\n\n` +
+        `This will unfollow all ${currentFollows.length} accounts you currently follow.\n\n` +
+        `Before continuing:\n` +
+        `• A local backup of your follow list will be saved automatically.\n` +
+        `• You can also export a snapshot from the Backups tab right now if you want extra copies.\n` +
+        `• If you later regret this, the Backups tab has a Follow List Recovery tool that can find and republish older versions of your follow list from relays.\n\n` +
+        `This action publishes an empty contact list to your relays. Continue?`,
+    );
+
+    if (!confirmed) {
+      setProcessing(false);
+      return;
+    }
+
+    try {
+      setProgress("Creating backup…");
+      const backup = backupService.createFollowListBackup(
+        session.pubkey,
+        currentFollows,
+        `Auto-backup before unfollowing everyone (${currentFollows.length} follows)`,
+      );
+      backupService.saveBackup(backup);
+
+      setProgress(
+        `Unfollowing ${currentFollows.length} account${currentFollows.length === 1 ? "" : "s"}…`,
+      );
+      await unfollowMultipleUsers(currentFollows, session.relays);
+
+      setProgress("");
+      setDecimatedCount(currentFollows.length);
+      setTotalFollows(0);
+      setSelectedUsers([]);
+      setShowShareModal(true);
+    } catch (err) {
+      console.error("Unfollow everyone error:", err);
+      setError(getErrorMessage(err, "Failed to unfollow everyone"));
+    } finally {
+      setProcessing(false);
+    }
+  };
+
   const handleDecimate = async () => {
     if (!session || selectedUsers.length === 0) return;
 
@@ -816,6 +888,36 @@ export default function Decimator() {
             Cancel
           </button>
         )}
+      </div>
+
+      {/* Nuclear option — its own card so it's visually distinct from the normal flow */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 mt-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+          Unfollow Everyone
+        </h2>
+        <button
+          onClick={handleUnfollowEveryone}
+          disabled={processing || totalFollows === 0}
+          className="w-full bg-yellow-500 hover:bg-yellow-600 disabled:bg-gray-400 disabled:cursor-not-allowed text-gray-900 disabled:text-white font-semibold py-3 px-6 rounded-lg transition-colors flex items-center justify-center gap-2"
+        >
+          <Trash2 className="w-5 h-5" />
+          Unfollow Everyone
+        </button>
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-300 dark:border-red-800 rounded-lg p-4 mt-3">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-red-900 dark:text-red-200">
+              <p className="font-semibold mb-1">This drops every follow you have.</p>
+              <p className="leading-relaxed">
+                Publishes an empty contact list. A local backup is saved
+                automatically, and the <strong>Backups tab</strong> has a Follow
+                List Recovery tool that can rebuild your list from older relay
+                copies if you change your mind. Still, take a fresh export there
+                first if this matters to you.
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
 
       {/* Error Display */}

--- a/components/DecimatorWrapper.tsx
+++ b/components/DecimatorWrapper.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { User, LogOut, Skull } from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+import { useAuth } from "@/hooks/useAuth";
+import { useStore } from "@/lib/store";
+import Decimator from "./Decimator";
+import Footer from "./Footer";
+import DashboardNav from "./DashboardNav";
+import { Profile } from "@/types";
+import UserProfileModal from "./UserProfileModal";
+import GlobalUserSearch from "./GlobalUserSearch";
+import AuthModal from "./AuthModal";
+
+export default function DecimatorWrapper() {
+  const { session, disconnect } = useAuth();
+  const { userProfile } = useStore();
+  const [selectedProfile, setSelectedProfile] = useState<Profile | null>(null);
+  const [showAuthModal, setShowAuthModal] = useState(false);
+
+  const handleDisconnect = () => {
+    disconnect();
+    window.location.href = "/";
+  };
+
+  const handleUserSelect = (profile: Profile) => {
+    setSelectedProfile(profile);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
+      {session ? (
+        <>
+          {/* Signed-in Header */}
+          <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="flex justify-between items-center h-16 gap-4">
+                <Link
+                  href="/dashboard"
+                  className="flex items-center space-x-3 flex-shrink-0 hover:opacity-80 transition-opacity"
+                  title="Go to Dashboard"
+                >
+                  <Image
+                    src="/mutable_logo.svg"
+                    alt="Mutable"
+                    width={40}
+                    height={40}
+                  />
+                  <Image
+                    src="/mutable_text.svg"
+                    alt="Mutable"
+                    width={120}
+                    height={24}
+                    className="hidden sm:block"
+                  />
+                </Link>
+
+                <GlobalUserSearch onSelectUser={handleUserSelect} />
+
+                <div className="flex items-center space-x-4 flex-shrink-0">
+                  {/* User Profile Display - Desktop */}
+                  <div className="hidden md:flex items-center space-x-3">
+                    {userProfile?.picture ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={userProfile.picture}
+                        alt={
+                          userProfile.display_name || userProfile.name || "User"
+                        }
+                        className="w-8 h-8 rounded-full object-cover"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).src =
+                            'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"%3E%3Ccircle cx="12" cy="12" r="10"/%3E%3Cpath d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"/%3E%3Cpath d="M4 20c0-4 3.6-6 8-6s8 2 8 6"/%3E%3C/svg%3E';
+                        }}
+                      />
+                    ) : (
+                      <div className="w-8 h-8 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center">
+                        <User
+                          size={16}
+                          className="text-gray-600 dark:text-gray-300"
+                        />
+                      </div>
+                    )}
+                    <div className="flex flex-col">
+                      {userProfile && (
+                        <>
+                          <span className="text-sm font-medium text-gray-900 dark:text-white">
+                            {userProfile.display_name ||
+                              userProfile.name ||
+                              "Anonymous"}
+                          </span>
+                          {userProfile.nip05 && (
+                            <span className="text-xs text-gray-600 dark:text-gray-400">
+                              {userProfile.nip05}
+                            </span>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* User Avatar - Mobile */}
+                  <div className="md:hidden">
+                    {userProfile?.picture ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={userProfile.picture}
+                        alt={
+                          userProfile.display_name || userProfile.name || "User"
+                        }
+                        className="w-8 h-8 rounded-full object-cover"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).src =
+                            'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"%3E%3Ccircle cx="12" cy="12" r="10"/%3E%3Cpath d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"/%3E%3Cpath d="M4 20c0-4 3.6-6 8-6s8 2 8 6"/%3E%3C/svg%3E';
+                        }}
+                      />
+                    ) : (
+                      <div className="w-8 h-8 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center">
+                        <User
+                          size={16}
+                          className="text-gray-600 dark:text-gray-300"
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  <button
+                    onClick={handleDisconnect}
+                    className="flex items-center space-x-2 px-4 py-2 text-sm text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                    title="Disconnect"
+                  >
+                    <LogOut size={16} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          {/* Tab Navigation */}
+          <DashboardNav activePage="decimator" />
+        </>
+      ) : (
+        <>
+          {/* Anonymous Header */}
+          <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="flex justify-between items-center h-16 gap-4">
+                <Link
+                  href="/"
+                  className="flex items-center space-x-3 flex-shrink-0 hover:opacity-80 transition-opacity"
+                  title="Go to Home"
+                >
+                  <Image
+                    src="/mutable_logo.svg"
+                    alt="Mutable"
+                    width={40}
+                    height={40}
+                  />
+                  <Image
+                    src="/mutable_text.svg"
+                    alt="Mutable"
+                    width={120}
+                    height={24}
+                    className="hidden sm:block"
+                  />
+                </Link>
+
+                <div className="flex-1" />
+
+                <div className="flex items-center gap-3">
+                  <span className="hidden md:inline text-sm text-gray-600 dark:text-gray-400">
+                    Sign in to use Decimator
+                  </span>
+                  <button
+                    onClick={() => setShowAuthModal(true)}
+                    className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium flex items-center gap-2"
+                  >
+                    <User size={16} />
+                    Connect with Nostr
+                  </button>
+                </div>
+              </div>
+            </div>
+          </header>
+        </>
+      )}
+
+      <div className="flex-1 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800">
+        <main className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow">
+          {session ? (
+            <Decimator />
+          ) : (
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-8 text-center">
+              <div className="max-w-md mx-auto">
+                <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+                  <Skull
+                    size={32}
+                    className="text-red-600 dark:text-red-400"
+                  />
+                </div>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+                  Decimator
+                </h2>
+                <p className="text-gray-600 dark:text-gray-400 mb-6">
+                  Trim your follow list. Randomly remove a percentage of follows,
+                  shrink down to a target count, or nuke the whole list — with a
+                  local backup saved before any change.
+                </p>
+                <button
+                  onClick={() => setShowAuthModal(true)}
+                  className="px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium"
+                >
+                  Connect with Nostr to Get Started
+                </button>
+              </div>
+            </div>
+          )}
+        </main>
+      </div>
+
+      <Footer />
+
+      {/* User Profile Modal */}
+      {selectedProfile && (
+        <UserProfileModal
+          profile={selectedProfile}
+          onClose={() => setSelectedProfile(null)}
+        />
+      )}
+
+      {/* Auth Modal */}
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+      />
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutable",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- **Unfollow Everyone** option in Decimator — fills the gap left by the 50% slider cap and the target-count minimum of 2, with a deliberate UX so it can't be triggered accidentally.
- New top-level **/decimator** route mirroring the /purgatory pattern.
- Bumps version to **1.6.1**.

## Unfollow Everyone

Lives in its own card below the normal Decimator controls. Yellow CTA (dark text) + a red warning callout beneath it.

The handler:
1. Fetches the live follow list up front (so the confirm dialog shows the exact count, and the backup is accurate).
2. Refuses if the user has zero follows.
3. Auto-creates a local backup via the existing \`backupService\`.
4. Publishes an empty kind:3 via \`unfollowMultipleUsers\`.

The confirm dialog reminds the user that:
- a local backup is saved automatically,
- the Backups tab has a Follow List Recovery tool that can republish older relay copies,
- they can also export a fresh snapshot manually before committing.

## /decimator route

\`app/decimator/page.tsx\` (metadata + Suspense) wraps \`components/DecimatorWrapper.tsx\`, modeled on \`PurgatoryWrapper\`. Anonymous visitors see a Skull-icon landing card with a Connect-with-Nostr CTA; signed-in users get the standard dashboard header + DashboardNav and the existing \`<Decimator />\` component below.

\`DashboardNav\` now links \`decimator\` to \`/decimator\` instead of \`?tab=decimator\`. The dashboard tab routing still recognizes the query param for back-compat.

## Test plan

- [ ] Visit \`/decimator\` while signed out → see Skull landing card with Connect CTA.
- [ ] Visit \`/decimator\` while signed in → see standard dashboard header + nav + the Decimator UI.
- [ ] On Decimator with > 0 follows, click **Unfollow Everyone** → confirm dialog shows count, auto-backup is created in the Backups tab, empty kind:3 publishes, success modal opens.
- [ ] With zero follows, the button is disabled.
- [ ] Click **Unfollow Everyone** during processing → still disabled.
- [ ] Backups tab still shows the auto-snapshot created by the action.
- [ ] Old \`?tab=decimator\` deep link from the dashboard still loads Decimator (back-compat).